### PR TITLE
parameterize image name in Docker GH action

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -38,7 +38,7 @@ jobs:
         id: prepare-environment
         env:
           registry: "ghcr.io"
-          image_name: ${{ github.repository_owner }}/web-api-poc
+          image_name: ${{ github.repository_owner }}/${{ github.repository }}
         run: |
           NOW="$(date -u +'%Y%m%dT%H%M%SZ')"
           echo "now=$NOW" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Use the `${{ github.repository }}` to set the image name in the Docker GH action, rather than explicitly using `web-api-poc`.

Note: GH Actions were not yet enabled on this repo, generally and specifically for time triggered actions like the Docker action, so I enabled both.