### PR TITLE
update Actions with toml file location instead of python version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version-file: ".python-version"
+          python-version-file: "api/.python-version"
 
       - name: Install the project
         run: uv sync --only-dev

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version-file: "api/.python-version"
+          python-version-file: "api/pyproject.toml"
 
       - name: Install the project
         run: uv sync --only-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version-file: ".python-version"
+          python-version-file: "api/.python-version"
       
       - name: Install the  project
         run: uv sync --all-extras --dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version-file: "api/.python-version"
+          python-version-file: "api/pyproject.toml"
       
       - name: Install the  project
         run: uv sync --all-extras --dev


### PR DESCRIPTION
Specifying location of python version with location of pyproject.toml file instead of python version file per: 

https://docs.astral.sh/uv/guides/integration/github/#setting-up-python

Hope this will solve the error in https://github.com/RMI/pbtar/pull/7 
