### PR TITLE
update README with new repo name and after API service moved to `api/`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pbtar
-[![Test Status](https://github.com/RMI/web-api-poc/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/RMI/web-api-poc/actions/workflows/test.yml)
-[![Docker](https://github.com/RMI/web-api-poc/actions/workflows/docker-build-and-push.yml/badge.svg?branch=main)](https://github.com/RMI/web-api-poc/actions/workflows/docker-build-and-push.yml)
-[![Lint](https://github.com/RMI/web-api-poc/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/RMI/web-api-poc/actions/workflows/lint.yml)
+[![Test Status](https://github.com/RMI/pbtar/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/RMI/pbtar/actions/workflows/test.yml)
+[![Docker](https://github.com/RMI/pbtar/actions/workflows/docker-build-and-push.yml/badge.svg?branch=main)](https://github.com/RMI/pbtar/actions/workflows/docker-build-and-push.yml)
+[![Lint](https://github.com/RMI/pbtar/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/RMI/pbtar/actions/workflows/lint.yml)
 
 This project is a proof-of-concept (POC) web API built using the FastAPI library.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# web-api-poc
+# pbtar
 [![Test Status](https://github.com/RMI/web-api-poc/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/RMI/web-api-poc/actions/workflows/test.yml)
 [![Docker](https://github.com/RMI/web-api-poc/actions/workflows/docker-build-and-push.yml/badge.svg?branch=main)](https://github.com/RMI/web-api-poc/actions/workflows/docker-build-and-push.yml)
 [![Lint](https://github.com/RMI/web-api-poc/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/RMI/web-api-poc/actions/workflows/lint.yml)
@@ -18,8 +18,8 @@ To install, follow the [official installation guide](https://github.com/astral-s
 1. Clone the Repo
 
 ```
-git clone https://github.com/RMI/web-api-poc
-cd web-api-poc
+git clone https://github.com/RMI/pbtar
+cd pbtar
 ```
 
 2. Create and Activate the Virtual Environment
@@ -30,7 +30,7 @@ source .venv/bin/activate # macOS/Linux
 
 3. Install Dependencies
 ```
-uv sync
+uv sync --directory api
 ```
 
 ## Running the API
@@ -38,7 +38,7 @@ uv sync
 ### Locally serve the Fast API with:
 
 ```
-uv run main.py
+uv run --directory api main.py
 ```
 
 ### Run Fast API in docker container with: 
@@ -71,13 +71,13 @@ uv add <library>
 Testing is implemented using the `pytest` library. Run all tests locally with:
 
 ```
-uv run pytest
+uv run --directory api pytest
 ```
 
 Or, you can run specific test suites with:
 ```
-uv run pytest tests/test_unit.py        # to only run unit tests
-uv run pytest tests/test_integration.py # to only run integration tests
+uv run --directory api pytest tests/test_unit.py        # to only run unit tests
+uv run --directory api pytest tests/test_integration.py # to only run integration tests
 ```
 
 For test-only dependencies, add them using:
@@ -90,8 +90,8 @@ uv add --dev <library>
 This project follows the [black](https://github.com/psf/black) code formatting standard. Lint code by running:
 
 ```
-black path/to/file.py # to lint a single file
-black .               # to lint the entire directory
+uv run --directory api black path/to/file.py # to lint a single file
+uv run --directory api black .               # to lint the entire directory
 ```
 
 Ensure that your code is properly formatted before submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# pbtar
+# Pathways-based transition assessment repository (pbtar)
+
 [![Test Status](https://github.com/RMI/pbtar/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/RMI/pbtar/actions/workflows/test.yml)
 [![Docker](https://github.com/RMI/pbtar/actions/workflows/docker-build-and-push.yml/badge.svg?branch=main)](https://github.com/RMI/pbtar/actions/workflows/docker-build-and-push.yml)
 [![Lint](https://github.com/RMI/pbtar/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/RMI/pbtar/actions/workflows/lint.yml)

--- a/api/main.py
+++ b/api/main.py
@@ -16,7 +16,7 @@ except FileNotFoundError:
 
 app = FastAPI(
     # This info goes directly into /docs
-    title="RMI Web API poc",
+    title="Pathways-based transition assessment repository (pbtar)",
     # Description of API defined in docs/documentation.py for ease of reading
     description=description,
     summary="This project is a proof-of-concept (POC) web API built using the FastAPI library.",
@@ -27,7 +27,7 @@ app = FastAPI(
     },
     license_info={
         "name": "MIT",
-        "url": "https://github.com/RMI/web-api-poc/blob/main/LICENSE.txt",
+        "url": "https://github.com/RMI/pbtar/blob/main/LICENSE.txt",
     },
 )
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "web-api-poc"
+name = "pbtar"
 version = "0.1.0"
-description = "POC for web API using fastapi"
+description = "Pathways-based transition assessment repository (pbtar)"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.12"
 
 [[package]]
@@ -225,6 +226,43 @@ wheels = [
 ]
 
 [[package]]
+name = "pbtar"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "dotenv" },
+    { name = "fastapi" },
+    { name = "pydantic" },
+    { name = "uvicorn" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "black" },
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "fastapi", specifier = ">=0.115.8" },
+    { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "uvicorn", specifier = ">=0.34.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "black", specifier = ">=25.1.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pytest", specifier = ">=8.3.4" },
+    { name = "pytest-asyncio", specifier = ">=0.25.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.3.6"
 source = { registry = "https://pypi.org/simple" }
@@ -385,41 +423,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9", size = 76568 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/14/33a3a1352cfa71812a3a21e8c9bfb83f60b0011f5e36f2b1399d51928209/uvicorn-0.34.0-py3-none-any.whl", hash = "sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4", size = 62315 },
-]
-
-[[package]]
-name = "web-api-poc"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "dotenv" },
-    { name = "fastapi" },
-    { name = "pydantic" },
-    { name = "uvicorn" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "black" },
-    { name = "httpx" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "dotenv", specifier = ">=0.9.9" },
-    { name = "fastapi", specifier = ">=0.115.8" },
-    { name = "pydantic", specifier = ">=2.10.6" },
-    { name = "uvicorn", specifier = ">=0.34.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "black", specifier = ">=25.1.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "pytest", specifier = ">=8.3.4" },
-    { name = "pytest-asyncio", specifier = ">=0.25.3" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
 ]


### PR DESCRIPTION
- resolves #19 

note: also update the name and description in a couple Python scripts and updated `uv.lock` using `uv lock --directory api`