### PR TITLE
explicitly load API_KEY env var into API service build context

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,10 @@
 
 services:
   api:
-    build: 
+    build:
       context: api
+    environment:
+      - API_KEY
     container_name: pbtar-app
     ports:
       - '80:5000'

--- a/example.env
+++ b/example.env
@@ -1,0 +1,1 @@
+API_KEY=abc123


### PR DESCRIPTION
also adds `example.env` file for developer guidance

required by docker-compose to use env vars, see https://docs.docker.com/compose/how-tos/environment-variables/set-environment-variables/

assumes a `.env` file in the root directory (or more specifically, the run/build context of `docker compose`) with an `API_KEY` env var specified, e.g. `API_KEY=abc123`

note: [docker-compose docs advise](https://docs.docker.com/compose/how-tos/environment-variables/set-environment-variables/) against passing sensitive information through env vars and suggests using [secrets](https://docs.docker.com/compose/how-tos/use-secrets/) instead