### PR TITLE
prevent comment on PR thread for Dependabot PRs

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: "Pytest coverage comment"
         uses: MishaKav/pytest-coverage-comment@main
+        if: github.actor != 'dependabot[bot]'
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./api/pytest.xml


### PR DESCRIPTION
because Dependabot does not have access to the token for needed privilege to do so