### PR TITLE
add a minimal test frontend index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ curl -X 'GET' \
   -H 'X-API-Key: abc123'
 ```
 
+### Load a minimal frontend index.html file to test
+
+Defaults to the API key "abc123", but an alternate key (matching what is in your `.env` file) can be input and submitted on the page.
+
+```sh
+open frontend/index.html
+```
+
 ### Shutdown the docker container
 
 ```sh

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-
+# remove me
 services:
   api:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-# remove me
+
 services:
   api:
     build:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,9 +34,13 @@
 </script>
 
 enter API key:
-<input type="text" id="api_key">
+<input type="text" id="api_key" value="abc12">
 <button type="button" onclick="loadData()">submit</button>
 
 <hr>
 
 <table id="my_table"></table>
+
+<script>
+  loadData();
+</script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -41,6 +41,12 @@
       const tables_div = document.querySelector("div#tables_div");
       tables_div.innerHTML = "tables available: " + data.tables;
     });
+
+    callApi(document.getElementById("route").value, api_key = document.getElementById("api_key").value)
+    .then((data) => {
+      const response_div = document.querySelector("div#response_div");
+      response_div.innerHTML = JSON.stringify(data);
+    });
   }
 </script>
 
@@ -52,6 +58,14 @@ route: <input type="text" id="route" value="/api/dataset" onkeydown="if(event.ke
 
 <div id="tables_div"></div>
 <br>
+
+<hr>
+
+<h3>JSON response:</h3>
+<div id="response_div"></div>
+<br>
+
+<hr>
 
 <table id="my_table"></table>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,7 +34,7 @@
 </script>
 
 enter API key:
-<input type="text" id="api_key" value="abc12">
+<input type="text" id="api_key" value="abc123">
 <button type="button" onclick="loadData()">submit</button>
 
 <hr>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -40,8 +40,8 @@
   }
 </script>
 
-enter API key: <input type="text" id="api_key" value="abc123"><br>
-route: <input type="text" id="route" value="/api/dataset"><br>
+enter API key: <input type="text" id="api_key" value="abc123" onkeydown="if(event.key === 'Enter') { loadData(); }"><br>
+route: <input type="text" id="route" value="/api/dataset" onkeydown="if(event.key === 'Enter') { loadData(); }"><br>
 <button type="button" onclick="loadData()">submit</button>
 
 <hr>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,7 @@
     const url = "http://localhost" + path;
     try {
       const response = await fetch(url, {
+        method: "GET",
         headers: {
           'accept': 'application/json',
           'X-API-Key': api_key

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,11 +1,11 @@
 <script>
-  async function callApi(path) {
+  async function callApi(path, api_key) {
     const url = "http://localhost" + path;
     try {
       const response = await fetch(url, {
         headers: {
           'accept': 'application/json',
-          'X-API-Key': 'abc123'
+          'X-API-Key': api_key
         }
       });
       if (!response.ok) {
@@ -24,11 +24,19 @@
     return row(array[0],"keys","h") + array.map(o=>row(o,"values","d")).join("");
   }
 
-  callApi("/api/dataset")
+  function loadData() {
+    callApi("/api/dataset", api_key = document.getElementById("api_key").value)
     .then((data) => {
       const my_table = document.querySelector("table#my_table");
       my_table.innerHTML = arr2tbl(data);
     });
+  }
 </script>
+
+enter API key:
+<input type="text" id="api_key">
+<button type="button" onclick="loadData()">submit</button>
+
+<hr>
 
 <table id="my_table"></table>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,34 @@
+<script>
+  async function callApi(path) {
+    const url = "http://localhost" + path;
+    try {
+      const response = await fetch(url, {
+        headers: {
+          'accept': 'application/json',
+          'X-API-Key': 'abc123'
+        }
+      });
+      if (!response.ok) {
+        throw new Error(`Response status: ${response.status}`);
+      }
+
+      const json = await response.json();
+      return(json);
+    } catch (error) {
+      console.error(error.message);
+    }
+  }
+
+  function arr2tbl(array){
+    const row=(obj,what,cell)=>`<tr>${Object[what](obj).map(k=>`<t${cell}>${k}</t${cell}>`).join("")}<tr>`;
+    return row(array[0],"keys","h") + array.map(o=>row(o,"values","d")).join("");
+  }
+
+  callApi("/api/dataset")
+    .then((data) => {
+      const my_table = document.querySelector("table#my_table");
+      my_table.innerHTML = arr2tbl(data);
+    });
+</script>
+
+<table id="my_table"></table>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <script>
-  async function callApi(path, api_key) {
+  async function callApi(path, api_key = "") {
     const url = "http://localhost" + path;
     try {
       const response = await fetch(url, {
@@ -26,19 +26,28 @@
   }
 
   function loadData() {
-    callApi("/api/dataset", api_key = document.getElementById("api_key").value)
+    callApi(document.getElementById("route").value, api_key = document.getElementById("api_key").value)
     .then((data) => {
       const my_table = document.querySelector("table#my_table");
       my_table.innerHTML = arr2tbl(data);
     });
+
+    callApi("/tables")
+    .then((data) => {
+      const tables_div = document.querySelector("div#tables_div");
+      tables_div.innerHTML = "tables available: " + data.tables;
+    });
   }
 </script>
 
-enter API key:
-<input type="text" id="api_key" value="abc123">
+enter API key: <input type="text" id="api_key" value="abc123"><br>
+route: <input type="text" id="route" value="/api/dataset"><br>
 <button type="button" onclick="loadData()">submit</button>
 
 <hr>
+
+<div id="tables_div"></div>
+<br>
 
 <table id="my_table"></table>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,7 +29,11 @@
     callApi(document.getElementById("route").value, api_key = document.getElementById("api_key").value)
     .then((data) => {
       const my_table = document.querySelector("table#my_table");
-      my_table.innerHTML = arr2tbl(data);
+      if (Array.isArray(data)) {
+        my_table.innerHTML = arr2tbl(data);
+      } else {
+        my_table.innerHTML = null;
+      }
     });
 
     callApi("/tables")


### PR DESCRIPTION
- depends on #46 

Adds a minimal `index.html` front end that can pull data through the API service using JavaScript. By default it uses the API key "abc123" and loads the table at route `/api/dataset`, but both the API and the route can be modified by the user and resubmitted. Additionally, it pulls from the route `/api/tables` and prints a list of the available tables. It also prints the JSON response as text.