### PR TITLE
set uv/python dependency checks to weekly and group minor and patch PRs together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,12 @@ updates:
   - package-ecosystem: "uv"
     directory: "/api"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "patch"
+          - "minor"
 
   - package-ecosystem: "docker"
     directories:


### PR DESCRIPTION
This should help keep the (often) frequent Python pkg updates under control by only checking for updates once per week, and any minor or patch version updates (i.e. not requiring as much attention to review) should get grouped into a single PR. Major versions should continue to have individual PRs which likely require more cautious review.