### PR TITLE
import `declarative_base()` from `sqlalchemy.orm` as suggested in pytest warning

### DIFF
--- a/api/src/models/sql_models.py
+++ b/api/src/models/sql_models.py
@@ -9,8 +9,7 @@ from sqlalchemy import (
     UniqueConstraint,
     func,
 )
-from sqlalchemy.orm import relationship
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship, declarative_base
 
 Base = declarative_base()
 


### PR DESCRIPTION
resolves this warning from pytest:
```sh
=========================================== warnings summary ===========================================
src/models/sql_models.py:15
  /Users/cjrmi/github/rmi/pbtar/api/src/models/sql_models.py:15: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    Base = declarative_base()
```