### PR TITLE
docs: gains status badge for DB tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Pathways-based transition assessment repository (pbtar)
 
+[![Test DB service](https://github.com/RMI/pbtar/actions/workflows/db-test.yml/badge.svg)](https://github.com/RMI/pbtar/actions/workflows/db-test.yml)
+
 [![Test Status](https://github.com/RMI/pbtar/actions/workflows/api-test.yml/badge.svg?branch=main)](https://github.com/RMI/pbtar/actions/workflows/api-test.yml)
-[![Docker](https://github.com/RMI/pbtar/actions/workflows/api-docker-build-and-push.yml/badge.svg?branch=main)](https://github.com/RMI/pbtar/actions/workflows/api-docker-build-and-push.yml)
 [![Lint](https://github.com/RMI/pbtar/actions/workflows/api-lint.yml/badge.svg?branch=main)](https://github.com/RMI/pbtar/actions/workflows/api-lint.yml)
+[![Docker](https://github.com/RMI/pbtar/actions/workflows/api-docker-build-and-push.yml/badge.svg?branch=main)](https://github.com/RMI/pbtar/actions/workflows/api-docker-build-and-push.yml)
 
 ## Running the API
 


### PR DESCRIPTION
Also re-ordered the API test badge order in terms of scope (unit -> lint -> build)