### PR TITLE
feat(frontend): serve the frontend statically

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,10 +17,15 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM nginx:stable-alpine
+FROM node:20-slim
+
+WORKDIR /app
+
+# Install serve globally
+RUN npm install -g serve
 
 # Copy built assets from the build stage
-COPY --from=build /app/dist /usr/share/nginx/html
+COPY --from=build /app/dist /app/dist
 
-# Start nginx
-CMD ["nginx", "-g", "daemon off;"]
+# Start serve static file server
+CMD ["serve", "-s", "dist", "-l", "80"]

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -8,6 +8,18 @@ export default defineConfig({
     open: true,
     port: 3000,
   },
+  build: {
+    // Output directory - this is already the default
+    outDir: 'dist',
+    // Generate assets with content hashes for better caching
+    assetsDir: 'assets',
+    // Add source maps for debugging if needed
+    sourcemap: false,
+    // Pre-optimize dependencies
+    commonjsOptions: {
+      include: [/node_modules/],
+    }
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
In this PR, I build the React front-end statically. This allows us to switch from using `nginx` to the much more lean/ lightweight `serve` (a server for static SPAs https://www.npmjs.com/package/serve)

It is unlikely we will need anything more than this, and it will allow a simplified deployment mechanism.


