### PR TITLE
chore(frontend): satisfy the frontend linter, and styler

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -12,6 +12,12 @@ export default [
       react: reactPlugin,
     },
     languageOptions: {
+      globals: {
+        console: true,
+        document: true,
+        window: true,
+        navigator: true
+      },
       parserOptions: {
         ecmaFeatures: {
           jsx: true,

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -16,7 +16,16 @@ export default [
         console: true,
         document: true,
         window: true,
-        navigator: true
+        navigator: true,
+
+        // Timer functions
+        setTimeout: true,
+        clearTimeout: true,
+
+        // Network APIs
+        fetch: true,
+        Request: true,
+        Response: true
       },
       parserOptions: {
         ecmaFeatures: {

--- a/frontend/src/components/ScenarioCard.test.jsx
+++ b/frontend/src/components/ScenarioCard.test.jsx
@@ -1,58 +1,62 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import ScenarioCard from './ScenarioCard';
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ScenarioCard from "./ScenarioCard";
 
-describe('ScenarioCard', () => {
+describe("ScenarioCard", () => {
   const mockScenario = {
-    name: 'Net Zero 2050',
-    nature: 'Normative',
-    description: 'A scenario showing pathways to carbon neutrality by 2050',
-    source: 'IEA',
-    created_on: '2022-01-15',
-    time_horizon: '2050',
-    target_temperature: '1.5°C',
-    usage: 'Policy Analysis',
+    name: "Net Zero 2050",
+    nature: "Normative",
+    description: "A scenario showing pathways to carbon neutrality by 2050",
+    source: "IEA",
+    created_on: "2022-01-15",
+    time_horizon: "2050",
+    target_temperature: "1.5°C",
+    usage: "Policy Analysis",
   };
 
-  it('renders scenario name and details correctly', () => {
+  it("renders scenario name and details correctly", () => {
     render(<ScenarioCard scenario={mockScenario} />);
-    
-    expect(screen.getByText('Net Zero 2050')).toBeInTheDocument();
-    expect(screen.getByText('Normative')).toBeInTheDocument();
-    expect(screen.getByText('A scenario showing pathways to carbon neutrality by 2050')).toBeInTheDocument();
-    expect(screen.getByText('IEA')).toBeInTheDocument();
+
+    expect(screen.getByText("Net Zero 2050")).toBeInTheDocument();
+    expect(screen.getByText("Normative")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "A scenario showing pathways to carbon neutrality by 2050",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("IEA")).toBeInTheDocument();
   });
 
-  it('displays the correct time information', () => {
+  it("displays the correct time information", () => {
     render(<ScenarioCard scenario={mockScenario} />);
-    
-    expect(screen.getByText('Published: 2022-01-15')).toBeInTheDocument();
-    expect(screen.getByText('Target: 2050')).toBeInTheDocument();
+
+    expect(screen.getByText("Published: 2022-01-15")).toBeInTheDocument();
+    expect(screen.getByText("Target: 2050")).toBeInTheDocument();
   });
 
-  it('displays the correct temperature target', () => {
+  it("displays the correct temperature target", () => {
     render(<ScenarioCard scenario={mockScenario} />);
-    
-    expect(screen.getByText('1.5°C')).toBeInTheDocument();
+
+    expect(screen.getByText("1.5°C")).toBeInTheDocument();
   });
 
-  it('renders the correct icon for Normative scenario', () => {
+  it("renders the correct icon for Normative scenario", () => {
     render(<ScenarioCard scenario={mockScenario} />);
-    
-    expect(screen.getByText('🎯')).toBeInTheDocument();
+
+    expect(screen.getByText("🎯")).toBeInTheDocument();
   });
 
-  it('renders the correct icon for Descriptive scenario', () => {
-    const descriptiveScenario = { ...mockScenario, nature: 'Descriptive' };
+  it("renders the correct icon for Descriptive scenario", () => {
+    const descriptiveScenario = { ...mockScenario, nature: "Descriptive" };
     render(<ScenarioCard scenario={descriptiveScenario} />);
-    
-    expect(screen.getByText('📊')).toBeInTheDocument();
+
+    expect(screen.getByText("📊")).toBeInTheDocument();
   });
 
-  it('renders the correct icon for Exploratory scenario', () => {
-    const exploratoryScenario = { ...mockScenario, nature: 'Exploratory' };
+  it("renders the correct icon for Exploratory scenario", () => {
+    const exploratoryScenario = { ...mockScenario, nature: "Exploratory" };
     render(<ScenarioCard scenario={exploratoryScenario} />);
-    
-    expect(screen.getByText('🔍')).toBeInTheDocument();
+
+    expect(screen.getByText("🔍")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/ScenariosGrid.test.jsx
+++ b/frontend/src/components/ScenariosGrid.test.jsx
@@ -1,36 +1,36 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import ScenariosGrid from './ScenariosGrid';
-import { callApi } from '../utils/api';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ScenariosGrid from "./ScenariosGrid";
+import { callApi } from "../utils/api";
 
 // Mock the API module
-vi.mock('../utils/api', () => ({
+vi.mock("../utils/api", () => ({
   callApi: vi.fn(),
 }));
 
-describe('ScenariosGrid', () => {
+describe("ScenariosGrid", () => {
   const mockScenarios = [
     {
       id: 1,
-      name: 'Scenario 1',
-      nature: 'Normative',
-      description: 'Description 1',
-      source: 'Source 1',
-      created_on: '2023-01-01',
-      time_horizon: '2030',
-      target_temperature: '1.5°C',
-      usage: 'Analysis',
+      name: "Scenario 1",
+      nature: "Normative",
+      description: "Description 1",
+      source: "Source 1",
+      created_on: "2023-01-01",
+      time_horizon: "2030",
+      target_temperature: "1.5°C",
+      usage: "Analysis",
     },
     {
       id: 2,
-      name: 'Scenario 2',
-      nature: 'Descriptive',
-      description: 'Description 2',
-      source: 'Source 2',
-      created_on: '2023-02-01',
-      time_horizon: '2040',
-      target_temperature: '2.0°C',
-      usage: 'Policy',
+      name: "Scenario 2",
+      nature: "Descriptive",
+      description: "Description 2",
+      source: "Source 2",
+      created_on: "2023-02-01",
+      time_horizon: "2040",
+      target_temperature: "2.0°C",
+      usage: "Policy",
     },
   ];
 
@@ -39,74 +39,76 @@ describe('ScenariosGrid', () => {
     callApi.mockResolvedValue(mockScenarios);
   });
 
-  it('loads and displays scenarios on mount', async () => {
+  it("loads and displays scenarios on mount", async () => {
     render(<ScenariosGrid />);
-    
-    expect(callApi).toHaveBeenCalledWith('/scenarios', 'abc123');
-    
+
+    expect(callApi).toHaveBeenCalledWith("/scenarios", "abc123");
+
     await waitFor(() => {
-      expect(screen.getByText('Scenario 1')).toBeInTheDocument();
-      expect(screen.getByText('Scenario 2')).toBeInTheDocument();
+      expect(screen.getByText("Scenario 1")).toBeInTheDocument();
+      expect(screen.getByText("Scenario 2")).toBeInTheDocument();
     });
   });
 
-  it('displays loading state while fetching scenarios', async () => {
+  it("displays loading state while fetching scenarios", async () => {
     // Delay API response
-    callApi.mockImplementation(() => new Promise(resolve => {
-      setTimeout(() => resolve(mockScenarios), 100);
-    }));
-    
+    callApi.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve(mockScenarios), 100);
+        }),
+    );
+
     render(<ScenariosGrid />);
-    
+
     // Wait for scenarios to load
     await waitFor(() => {
-      expect(screen.getByText('Scenario 1')).toBeInTheDocument();
+      expect(screen.getByText("Scenario 1")).toBeInTheDocument();
     });
   });
 
-  it('handles API errors gracefully', async () => {
+  it("handles API errors gracefully", async () => {
     // Mock API error
-    callApi.mockRejectedValue(new Error('Failed to fetch'));
-    
-    render(<ScenariosGrid />);
+    callApi.mockRejectedValue(new Error("Failed to fetch"));
 
+    render(<ScenariosGrid />);
   });
 
-  it('allows changing the API key', async () => {
+  it("allows changing the API key", async () => {
     render(<ScenariosGrid />);
-    
+
     // Open developer controls (if they're in a details/summary)
-    const summary = screen.getByText('developer');
+    const summary = screen.getByText("developer");
     fireEvent.click(summary);
-    
+
     // Find API key input and change it
-    const apiKeyInput = screen.getByDisplayValue('abc123');
-    fireEvent.change(apiKeyInput, { target: { value: 'new-key' } });
-    
+    const apiKeyInput = screen.getByDisplayValue("abc123");
+    fireEvent.change(apiKeyInput, { target: { value: "new-key" } });
+
     // Click load button
-    const loadButton = screen.getByText('Load Data');
+    const loadButton = screen.getByText("Load Data");
     fireEvent.click(loadButton);
-    
+
     // Verify API was called with new key
-    expect(callApi).toHaveBeenCalledWith('/scenarios', 'new-key');
+    expect(callApi).toHaveBeenCalledWith("/scenarios", "new-key");
   });
 
-  it('allows changing the API endpoint', async () => {
+  it("allows changing the API endpoint", async () => {
     render(<ScenariosGrid />);
-    
+
     // Open developer controls
-    const summary = screen.getByText('developer');
+    const summary = screen.getByText("developer");
     fireEvent.click(summary);
-    
+
     // Find route input and change it
-    const routeInput = screen.getByDisplayValue('/scenarios');
-    fireEvent.change(routeInput, { target: { value: '/organizations' } });
-    
+    const routeInput = screen.getByDisplayValue("/scenarios");
+    fireEvent.change(routeInput, { target: { value: "/organizations" } });
+
     // Click load button
-    const loadButton = screen.getByText('Load Data');
+    const loadButton = screen.getByText("Load Data");
     fireEvent.click(loadButton);
-    
+
     // Verify API was called with new endpoint
-    expect(callApi).toHaveBeenCalledWith('/organizations', 'abc123');
+    expect(callApi).toHaveBeenCalledWith("/organizations", "abc123");
   });
 });

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,6 +1,6 @@
-import { afterEach } from 'vitest';
-import { cleanup } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom";
 
 // Run cleanup after each test case (e.g. clearing jsdom)
 afterEach(() => {

--- a/frontend/src/utils/api.jsx
+++ b/frontend/src/utils/api.jsx
@@ -2,7 +2,7 @@ export const callApi = async (path, apiKey = "") => {
   // For browser environment, use the public URL
   const isInBrowser = typeof window !== "undefined";
 
- // Get API port from environment variables, with fallback to 8000
+  // Get API port from environment variables, with fallback to 8000
   const apiPort = import.meta.env.PBTAR_API_PORT || "8000";
 
   // Base URL logic - use different approach for browser vs container


### PR DESCRIPTION
This PR ensures that both `npm run lint` and `npm run format:check` pass without error. 

A lot of this amounted to simply adding common globals to the `eslint.config.mjs` file, specifically:
Browser Environment Globals:
- `console: true` - Allows using `console.log()`, `console.error()`, etc.
- `document: true` - Allows accessing the DOM via `document.getElementById()`, etc.
- `window: true` - Allows using the browser's window object (`window.location`, `events`, etc.)
- `navigator: true` - Allows access to browser information (`navigator.userAgent`, etc.)

Timer Function Globals:
- `setTimeout: true` - Allows using `setTimeout()` for delayed execution
- `clearTimeout: true` - Allows using `clearTimeout()` to cancel timeouts

Network API Globals:
- `fetch: true` - Allows using the `fetch()` API for HTTP requests
- `Request: true` - Allows using the Request constructor for fetch API
- `Response: true` - Allows using the Response class for fetch API

By defining these explicitly, it is clear which globals the React app depends on.

Finally, I ran `npm run format` to style all files using `prettier`. 