### PR TITLE
ci(actions): only trigger actions when relevant files change

### DIFF
--- a/.github/workflows/api-docker-build-and-push.yml
+++ b/.github/workflows/api-docker-build-and-push.yml
@@ -9,12 +9,14 @@ on:
     paths:
       - 'api/**'
       - '.github/workflows/api-docker-build-and-push.yml'
+      - 'docker-compose.yml'
   pull_request:
     branches:
       - main
     paths:
       - 'api/**'
       - '.github/workflows/api-docker-build-and-push.yml'
+      - 'docker-compose.yml'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/api-docker-build-and-push.yml
+++ b/.github/workflows/api-docker-build-and-push.yml
@@ -6,9 +6,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'api/**'
+      - '.github/workflows/api-docker-build-and-push.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'api/**'
+      - '.github/workflows/api-docker-build-and-push.yml'
+  workflow_dispatch:
 
 env:
   SERVICE: api

--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -4,10 +4,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'api/**'
+      - '.github/workflows/api-lint.yml'
   pull_request:
     branches:
       - main
-
+    paths:
+      - 'api/**'
+      - '.github/workflows/api-lint.yml'
+  workflow_dispatch:
 jobs:
   ruff:
     name: Run ruff code formatter

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -4,9 +4,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'api/**'
+      - '.github/workflows/api-test.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'api/**'
+      - '.github/workflows/api-test.yml'
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/db-test.yml
+++ b/.github/workflows/db-test.yml
@@ -5,10 +5,12 @@ on:
     branches: [ main ]
     paths:
       - 'database/**'
+      - '.github/workflows/db-test.yml'
       - 'docker-compose.yaml'
   pull_request:
     paths:
       - 'database/**'
+      - '.github/workflows/db-test.yml'
       - 'docker-compose.yaml'
   workflow_dispatch:
 

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -4,9 +4,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-lint.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-lint.yml'
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -4,9 +4,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-test.yml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-test.yml'
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
This PR makes changes to all of the service-related GH actions (linting, testing, etc.) to ensure that they only get run when relevant files in the directory are changed (or the action itself). 

Given the re-working of this repo, this will save us waiting unnecessarily long for irrelevant actions to run when we edit `frontend` (or any service for that matter).

I also added a `workflow_dispatch` trigger for good measure. 

Closes #84 