### PR TITLE
feat(frontend): gains "About Us" page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
+import AboutPage from "./pages/AboutPage";
 
 function App() {
   return (
@@ -10,6 +11,7 @@ function App() {
         <main className="flex-grow">
           <Routes>
             <Route path="/" element={<h1>Home Page</h1>} />
+            <Route path="/about" element={<AboutPage />} />
           </Routes>
         </main>
         <Footer />

--- a/frontend/src/pages/AboutPage.test.tsx
+++ b/frontend/src/pages/AboutPage.test.tsx
@@ -16,94 +16,109 @@ describe("AboutPage component", () => {
   it("renders the site title", () => {
     renderAboutPage();
     // Assuming your AboutPage has a site title text
-    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
-      'About the Climate Transition Scenarios Repository'
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "About the Climate Transition Scenarios Repository",
     );
   });
 
-  it('displays all section headings', () => {
+  it("displays all section headings", () => {
     renderAboutPage();
     // Check for section headings
-    expect(screen.getByText('Purpose')).toBeInTheDocument();
-    expect(screen.getByText('Climate Transition Assessments')).toBeInTheDocument();
-    expect(screen.getByText('How to Use This Repository')).toBeInTheDocument();
+    expect(screen.getByText("Purpose")).toBeInTheDocument();
+    expect(
+      screen.getByText("Climate Transition Assessments"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("How to Use This Repository")).toBeInTheDocument();
   });
 
-  it('shows all steps in the usage guide', () => {
+  it("shows all steps in the usage guide", () => {
     renderAboutPage();
     // Check for the numbered steps
-    expect(screen.getByText('1. Browse Scenarios')).toBeInTheDocument();
-    expect(screen.getByText('2. Filter and Search')).toBeInTheDocument();
-    expect(screen.getByText('3. Compare Scenarios')).toBeInTheDocument();
-    expect(screen.getByText('4. Access Data')).toBeInTheDocument();
+    expect(screen.getByText("1. Browse Scenarios")).toBeInTheDocument();
+    expect(screen.getByText("2. Filter and Search")).toBeInTheDocument();
+    expect(screen.getByText("3. Compare Scenarios")).toBeInTheDocument();
+    expect(screen.getByText("4. Access Data")).toBeInTheDocument();
   });
 
-  it('contains the external link to learn more about CTAs', () => {
+  it("contains the external link to learn more about CTAs", () => {
     renderAboutPage();
-    const learnMoreLink = screen.getByText('Learn more about Climate Transition Assessments');
-    expect(learnMoreLink).toBeInTheDocument();
-    expect(learnMoreLink.closest('a')).toHaveAttribute(
-      'href',
-      'https://rmi.org/transitionfinance/'
+    const learnMoreLink = screen.getByText(
+      "Learn more about Climate Transition Assessments",
     );
-    expect(learnMoreLink.closest('a')).toHaveAttribute('target', '_blank');
-    expect(learnMoreLink.closest('a')).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(learnMoreLink).toBeInTheDocument();
+    expect(learnMoreLink.closest("a")).toHaveAttribute(
+      "href",
+      "https://rmi.org/transitionfinance/",
+    );
+    expect(learnMoreLink.closest("a")).toHaveAttribute("target", "_blank");
+    expect(learnMoreLink.closest("a")).toHaveAttribute(
+      "rel",
+      "noopener noreferrer",
+    );
   });
 
-  it('renders the lucide icons', () => {
+  it("renders the lucide icons", () => {
     renderAboutPage();
     // At least two icons should be present (Mail and ExternalLink)
-    const svgElements = document.querySelectorAll('svg');
+    const svgElements = document.querySelectorAll("svg");
     expect(svgElements.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('contains the key informational paragraphs', () => {
+  it("contains the key informational paragraphs", () => {
     renderAboutPage();
     // Check for some distinctive text content
-    expect(screen.getByText(/designed to help financial institutions/i)).toBeInTheDocument();
-    expect(screen.getByText(/CTAs are most effective when they consider multiple transition scenarios/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/designed to help financial institutions/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /CTAs are most effective when they consider multiple transition scenarios/i,
+      ),
+    ).toBeInTheDocument();
   });
 
-  describe('accessibility', () => {
-    it('has proper heading hierarchy', () => {
-        renderAboutPage();
-        const h1Elements = screen.getAllByRole('heading', { level: 1 });
-        expect(h1Elements).toHaveLength(1);
+  describe("accessibility", () => {
+    it("has proper heading hierarchy", () => {
+      renderAboutPage();
+      const h1Elements = screen.getAllByRole("heading", { level: 1 });
+      expect(h1Elements).toHaveLength(1);
 
-        const h2Elements = screen.getAllByRole('heading', { level: 2 });
-        expect(h2Elements.length).toBeGreaterThanOrEqual(4); // 4 section headers
+      const h2Elements = screen.getAllByRole("heading", { level: 2 });
+      expect(h2Elements.length).toBeGreaterThanOrEqual(4); // 4 section headers
 
-        const h3Elements = screen.getAllByRole('heading', { level: 3 });
-        expect(h3Elements.length).toBe(4); // 4 steps
+      const h3Elements = screen.getAllByRole("heading", { level: 3 });
+      expect(h3Elements.length).toBe(4); // 4 steps
     });
 
-    it('provides proper attributes for external links', () => {
-        renderAboutPage();
-        const externalLinks = screen.getAllByRole('link').filter(
-            link => link.getAttribute('target') === '_blank'
-        );
-        
-        externalLinks.forEach(link => {
-            expect(link).toHaveAttribute('rel', 'noopener noreferrer');
-        });
+    it("provides proper attributes for external links", () => {
+      renderAboutPage();
+      const externalLinks = screen
+        .getAllByRole("link")
+        .filter((link) => link.getAttribute("target") === "_blank");
+
+      externalLinks.forEach((link) => {
+        expect(link).toHaveAttribute("rel", "noopener noreferrer");
+      });
     });
   });
 
-  describe('styling and layout', () => {
-    it('uses container class for layout', () => {
-        renderAboutPage();
-        const container = screen.getByText('About the Climate Transition Scenarios Repository').closest('div.container');
-        expect(container).toBeInTheDocument();
+  describe("styling and layout", () => {
+    it("uses container class for layout", () => {
+      renderAboutPage();
+      const container = screen
+        .getByText("About the Climate Transition Scenarios Repository")
+        .closest("div.container");
+      expect(container).toBeInTheDocument();
     });
-    
-    it('has proper section styling', () => {
-        renderAboutPage();
-        const sections = document.querySelectorAll('section');
-        sections.forEach(section => {
-            expect(section).toHaveClass('bg-white');
-            expect(section).toHaveClass('rounded-lg');
-            expect(section).toHaveClass('shadow-md');
-        });
+
+    it("has proper section styling", () => {
+      renderAboutPage();
+      const sections = document.querySelectorAll("section");
+      sections.forEach((section) => {
+        expect(section).toHaveClass("bg-white");
+        expect(section).toHaveClass("rounded-lg");
+        expect(section).toHaveClass("shadow-md");
+      });
     });
   });
 });

--- a/frontend/src/pages/AboutPage.test.tsx
+++ b/frontend/src/pages/AboutPage.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import AboutPage from "./AboutPage";
+
+describe("AboutPage component", () => {
+  // Helper function to render AboutPage with MemoryRouter
+  const renderAboutPage = () => {
+    return render(
+      <MemoryRouter>
+        <AboutPage />
+      </MemoryRouter>,
+    );
+  };
+
+  it("renders the site title", () => {
+    renderAboutPage();
+    // Assuming your AboutPage has a site title text
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'About the Climate Transition Scenarios Repository'
+    );
+  });
+
+  it('displays all section headings', () => {
+    renderAboutPage();
+    // Check for section headings
+    expect(screen.getByText('Purpose')).toBeInTheDocument();
+    expect(screen.getByText('Climate Transition Assessments')).toBeInTheDocument();
+    expect(screen.getByText('How to Use This Repository')).toBeInTheDocument();
+  });
+
+  it('shows all steps in the usage guide', () => {
+    renderAboutPage();
+    // Check for the numbered steps
+    expect(screen.getByText('1. Browse Scenarios')).toBeInTheDocument();
+    expect(screen.getByText('2. Filter and Search')).toBeInTheDocument();
+    expect(screen.getByText('3. Compare Scenarios')).toBeInTheDocument();
+    expect(screen.getByText('4. Access Data')).toBeInTheDocument();
+  });
+
+  it('contains the external link to learn more about CTAs', () => {
+    renderAboutPage();
+    const learnMoreLink = screen.getByText('Learn more about Climate Transition Assessments');
+    expect(learnMoreLink).toBeInTheDocument();
+    expect(learnMoreLink.closest('a')).toHaveAttribute(
+      'href',
+      'https://rmi.org/transitionfinance/'
+    );
+    expect(learnMoreLink.closest('a')).toHaveAttribute('target', '_blank');
+    expect(learnMoreLink.closest('a')).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders the lucide icons', () => {
+    renderAboutPage();
+    // At least two icons should be present (Mail and ExternalLink)
+    const svgElements = document.querySelectorAll('svg');
+    expect(svgElements.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('contains the key informational paragraphs', () => {
+    renderAboutPage();
+    // Check for some distinctive text content
+    expect(screen.getByText(/designed to help financial institutions/i)).toBeInTheDocument();
+    expect(screen.getByText(/CTAs are most effective when they consider multiple transition scenarios/i)).toBeInTheDocument();
+  });
+
+  describe('accessibility', () => {
+    it('has proper heading hierarchy', () => {
+        renderAboutPage();
+        const h1Elements = screen.getAllByRole('heading', { level: 1 });
+        expect(h1Elements).toHaveLength(1);
+
+        const h2Elements = screen.getAllByRole('heading', { level: 2 });
+        expect(h2Elements.length).toBeGreaterThanOrEqual(4); // 4 section headers
+
+        const h3Elements = screen.getAllByRole('heading', { level: 3 });
+        expect(h3Elements.length).toBe(4); // 4 steps
+    });
+
+    it('provides proper attributes for external links', () => {
+        renderAboutPage();
+        const externalLinks = screen.getAllByRole('link').filter(
+            link => link.getAttribute('target') === '_blank'
+        );
+        
+        externalLinks.forEach(link => {
+            expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+        });
+    });
+  });
+
+  describe('styling and layout', () => {
+    it('uses container class for layout', () => {
+        renderAboutPage();
+        const container = screen.getByText('About the Climate Transition Scenarios Repository').closest('div.container');
+        expect(container).toBeInTheDocument();
+    });
+    
+    it('has proper section styling', () => {
+        renderAboutPage();
+        const sections = document.querySelectorAll('section');
+        sections.forEach(section => {
+            expect(section).toHaveClass('bg-white');
+            expect(section).toHaveClass('rounded-lg');
+            expect(section).toHaveClass('shadow-md');
+        });
+    });
+  });
+});

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { ExternalLink, Mail } from 'lucide-react';
+
+const AboutPage: React.FC = () => {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-3xl font-bold text-gray-800 mb-6">About the Climate Transition Scenarios Repository</h1>
+        
+        <section className="bg-white rounded-lg shadow-md p-6 mb-8">
+          <h2 className="text-xl font-semibold text-gray-800 mb-4">Purpose</h2>
+          <p className="text-gray-700 mb-4">
+            The Climate Transition Scenarios Repository is designed to help financial institutions 
+            efficiently discover, compare, and utilize diverse climate transition scenarios for their assessments.
+          </p>
+          <p className="text-gray-700 mb-4">
+            Our goal is to simplify the process of finding relevant scenarios and understanding their 
+            applications, enabling analysts to make more informed decisions when evaluating transition plans 
+            and climate-related financial risks.
+          </p>
+        </section>
+        
+        <section className="bg-white rounded-lg shadow-md p-6 mb-8">
+          <h2 className="text-xl font-semibold text-gray-800 mb-4">Climate Transition Assessments</h2>
+          <p className="text-gray-700 mb-4">
+            Climate Transition Assessments (CTAs) are valuable tools that help financial institutions evaluate 
+            how well their clients or investments are positioned for the transition to a low-carbon economy.
+          </p>
+          <p className="text-gray-700 mb-4">
+            At RMI, we believe that CTAs are most effective when they consider multiple transition scenarios, 
+            as this provides a more comprehensive view of potential futures and addresses data gaps that may exist 
+            in any single scenario.
+          </p>
+          <p className="text-gray-700 mb-4">
+            By providing access to diverse scenarios with expert analysis and recommendations, we aim to reduce 
+            the barriers to creating robust CTAs and improve the quality of climate-related financial analysis.
+          </p>
+          <div className="mt-6">
+            <a 
+              href="https://rmi.org/transitionfinance/" 
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center text-teal-600 hover:text-teal-800 transition-colors duration-200"
+            >
+              Learn more about Climate Transition Assessments
+              <ExternalLink size={16} className="ml-2" />
+            </a>
+          </div>
+        </section>
+        
+        <section className="bg-white rounded-lg shadow-md p-6 mb-8">
+          <h2 className="text-xl font-semibold text-gray-800 mb-4">How to Use This Repository</h2>
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-lg font-medium text-gray-800 mb-2">1. Browse Scenarios</h3>
+              <p className="text-gray-700">
+                Browse our curated list of climate transition scenarios to get a broad understanding of what's available.
+              </p>
+            </div>
+            
+            <div>
+              <h3 className="text-lg font-medium text-gray-800 mb-2">2. Filter and Search</h3>
+              <p className="text-gray-700">
+                Use our search and filter tools to narrow down scenarios based on specific criteria such as regions, 
+                sectors, temperature targets, or other attributes relevant to your assessment.
+              </p>
+            </div>
+            
+            <div>
+              <h3 className="text-lg font-medium text-gray-800 mb-2">3. Compare Scenarios</h3>
+              <p className="text-gray-700">
+                Read detailed information about each scenario, including RMI's expert analysis of their strengths, 
+                limitations, and appropriate use cases.
+              </p>
+            </div>
+            
+            <div>
+              <h3 className="text-lg font-medium text-gray-800 mb-2">4. Access Data</h3>
+              <p className="text-gray-700">
+                Find information on how to access the underlying data for scenarios you're interested in, 
+                either through direct downloads or links to original sources.
+              </p>
+            </div>
+          </div>
+        </section>
+        
+        <section className="bg-white rounded-lg shadow-md p-6">
+          <h2 className="text-xl font-semibold text-gray-800 mb-4">Contact Us</h2>
+          <p className="text-gray-700 mb-4">
+            If you have questions, feedback, or would like to learn more about how RMI can support your 
+            climate transition assessment work, please reach out to our team.
+          </p>
+          <a 
+            href="mailto:jhoffart@rmi.org" 
+            className="inline-flex items-center px-4 py-2 bg-teal-600 text-white rounded-md hover:bg-teal-700 transition-colors duration-200"
+          >
+            <Mail size={16} className="mr-2" />
+            Contact Us
+          </a>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default AboutPage;

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -1,43 +1,53 @@
-import React from 'react';
-import { ExternalLink, Mail } from 'lucide-react';
+import React from "react";
+import { ExternalLink, Mail } from "lucide-react";
 
 const AboutPage: React.FC = () => {
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="max-w-4xl mx-auto">
-        <h1 className="text-3xl font-bold text-gray-800 mb-6">About the Climate Transition Scenarios Repository</h1>
-        
+        <h1 className="text-3xl font-bold text-gray-800 mb-6">
+          About the Climate Transition Scenarios Repository
+        </h1>
+
         <section className="bg-white rounded-lg shadow-md p-6 mb-8">
           <h2 className="text-xl font-semibold text-gray-800 mb-4">Purpose</h2>
           <p className="text-gray-700 mb-4">
-            The Climate Transition Scenarios Repository is designed to help financial institutions 
-            efficiently discover, compare, and utilize diverse climate transition scenarios for their assessments.
+            The Climate Transition Scenarios Repository is designed to help
+            financial institutions efficiently discover, compare, and utilize
+            diverse climate transition scenarios for their assessments.
           </p>
           <p className="text-gray-700 mb-4">
-            Our goal is to simplify the process of finding relevant scenarios and understanding their 
-            applications, enabling analysts to make more informed decisions when evaluating transition plans 
-            and climate-related financial risks.
+            Our goal is to simplify the process of finding relevant scenarios
+            and understanding their applications, enabling analysts to make more
+            informed decisions when evaluating transition plans and
+            climate-related financial risks.
           </p>
         </section>
-        
+
         <section className="bg-white rounded-lg shadow-md p-6 mb-8">
-          <h2 className="text-xl font-semibold text-gray-800 mb-4">Climate Transition Assessments</h2>
+          <h2 className="text-xl font-semibold text-gray-800 mb-4">
+            Climate Transition Assessments
+          </h2>
           <p className="text-gray-700 mb-4">
-            Climate Transition Assessments (CTAs) are valuable tools that help financial institutions evaluate 
-            how well their clients or investments are positioned for the transition to a low-carbon economy.
+            Climate Transition Assessments (CTAs) are valuable tools that help
+            financial institutions evaluate how well their clients or
+            investments are positioned for the transition to a low-carbon
+            economy.
           </p>
           <p className="text-gray-700 mb-4">
-            At RMI, we believe that CTAs are most effective when they consider multiple transition scenarios, 
-            as this provides a more comprehensive view of potential futures and addresses data gaps that may exist 
-            in any single scenario.
+            At RMI, we believe that CTAs are most effective when they consider
+            multiple transition scenarios, as this provides a more comprehensive
+            view of potential futures and addresses data gaps that may exist in
+            any single scenario.
           </p>
           <p className="text-gray-700 mb-4">
-            By providing access to diverse scenarios with expert analysis and recommendations, we aim to reduce 
-            the barriers to creating robust CTAs and improve the quality of climate-related financial analysis.
+            By providing access to diverse scenarios with expert analysis and
+            recommendations, we aim to reduce the barriers to creating robust
+            CTAs and improve the quality of climate-related financial analysis.
           </p>
           <div className="mt-6">
-            <a 
-              href="https://rmi.org/transitionfinance/" 
+            <a
+              href="https://rmi.org/transitionfinance/"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center text-teal-600 hover:text-teal-800 transition-colors duration-200"
@@ -47,51 +57,68 @@ const AboutPage: React.FC = () => {
             </a>
           </div>
         </section>
-        
+
         <section className="bg-white rounded-lg shadow-md p-6 mb-8">
-          <h2 className="text-xl font-semibold text-gray-800 mb-4">How to Use This Repository</h2>
+          <h2 className="text-xl font-semibold text-gray-800 mb-4">
+            How to Use This Repository
+          </h2>
           <div className="space-y-4">
             <div>
-              <h3 className="text-lg font-medium text-gray-800 mb-2">1. Browse Scenarios</h3>
+              <h3 className="text-lg font-medium text-gray-800 mb-2">
+                1. Browse Scenarios
+              </h3>
               <p className="text-gray-700">
-                Browse our curated list of climate transition scenarios to get a broad understanding of what's available.
+                Browse our curated list of climate transition scenarios to get a
+                broad understanding of what's available.
               </p>
             </div>
-            
+
             <div>
-              <h3 className="text-lg font-medium text-gray-800 mb-2">2. Filter and Search</h3>
+              <h3 className="text-lg font-medium text-gray-800 mb-2">
+                2. Filter and Search
+              </h3>
               <p className="text-gray-700">
-                Use our search and filter tools to narrow down scenarios based on specific criteria such as regions, 
-                sectors, temperature targets, or other attributes relevant to your assessment.
+                Use our search and filter tools to narrow down scenarios based
+                on specific criteria such as regions, sectors, temperature
+                targets, or other attributes relevant to your assessment.
               </p>
             </div>
-            
+
             <div>
-              <h3 className="text-lg font-medium text-gray-800 mb-2">3. Compare Scenarios</h3>
+              <h3 className="text-lg font-medium text-gray-800 mb-2">
+                3. Compare Scenarios
+              </h3>
               <p className="text-gray-700">
-                Read detailed information about each scenario, including RMI's expert analysis of their strengths, 
-                limitations, and appropriate use cases.
+                Read detailed information about each scenario, including RMI's
+                expert analysis of their strengths, limitations, and appropriate
+                use cases.
               </p>
             </div>
-            
+
             <div>
-              <h3 className="text-lg font-medium text-gray-800 mb-2">4. Access Data</h3>
+              <h3 className="text-lg font-medium text-gray-800 mb-2">
+                4. Access Data
+              </h3>
               <p className="text-gray-700">
-                Find information on how to access the underlying data for scenarios you're interested in, 
-                either through direct downloads or links to original sources.
+                Find information on how to access the underlying data for
+                scenarios you're interested in, either through direct downloads
+                or links to original sources.
               </p>
             </div>
           </div>
         </section>
-        
+
         <section className="bg-white rounded-lg shadow-md p-6">
-          <h2 className="text-xl font-semibold text-gray-800 mb-4">Contact Us</h2>
+          <h2 className="text-xl font-semibold text-gray-800 mb-4">
+            Contact Us
+          </h2>
           <p className="text-gray-700 mb-4">
-            If you have questions, feedback, or would like to learn more about how RMI can support your 
-            climate transition assessment work, please reach out to our team.
+            If you have questions, feedback, or would like to learn more about
+            how RMI can support your climate transition assessment work, please
+            reach out to our team.
           </p>
-          <a 
-            href="mailto:jhoffart@rmi.org" 
+          <a
+            href="mailto:jhoffart@rmi.org"
             className="inline-flex items-center px-4 py-2 bg-teal-600 text-white rounded-md hover:bg-teal-700 transition-colors duration-200"
           >
             <Mail size={16} className="mr-2" />


### PR DESCRIPTION
In this PR, I add a simple "About Us" page component to the new `pages` directory (with associated unit tests). 
The component is routed in `App.tsx`