### PR TITLE
feat(tests): implement array validation in integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -49,6 +49,11 @@ jobs:
           docker compose logs
           exit 1
 
+      - name: Install jq
+        shell: bash
+        run: |
+          sudo apt-get install -y jq
+
       - name: run integration tests
         shell: bash
         run: |

--- a/tests/test-integration.sh
+++ b/tests/test-integration.sh
@@ -69,7 +69,7 @@ echo -e "\n\nchecking response key-value pairs:"
 check_response "http://localhost:8000/foo" '{"detail":"Not Found"}'
 check_response "http://localhost:8000/health" '{"status":"OK"}'
 check_response "http://localhost:8000/scenarios/1" '{"id":"1"}'
-check_response "http://localhost:8000/scenarios/1" '{"id":"1"}'
+check_response "http://localhost:8000/organizations/1" '{"id":"1"}'
 
 # Check that an array contains an element with specific key-value pair
 check_array_contains() {

--- a/tests/test-integration.sh
+++ b/tests/test-integration.sh
@@ -43,27 +43,51 @@ check_response_code "http://localhost:8000/xxx" 404
 check_response()
 {
   URL=$1
-  EXPECT=$2
-  RESPONSE=$( \
-  curl \
-    --silent \
-    "$URL"
-  )
+  EXPECT_JSON=$2
+  RESPONSE=$(curl --silent "$URL")
 
-  if [[ "$RESPONSE" != "$EXPECT"* ]];
-  then
-    echo ❌ "$URL": ${RESPONSE:0:15}... \(expected: "$EXPECT"\)
-    exit 1
+  # Extract keys from expected JSON
+  EXPECTED_KEYS=$(echo "$EXPECT_JSON" | jq -r 'keys[]')
+  
+  # Check each expected key exists with correct value
+  for KEY in $EXPECTED_KEYS; do
+    EXPECTED_VALUE=$(echo "$EXPECT_JSON" | jq -r ".[\"$KEY\"]")
+    ACTUAL_VALUE=$(echo "$RESPONSE" | jq -r ".[\"$KEY\"]" 2>/dev/null)
+    
+    if [ "$ACTUAL_VALUE" == "$EXPECTED_VALUE" ]; then
+      echo "✅ $URL: Key '$KEY' has expected value '$EXPECTED_VALUE'"
+    else
+      echo "❌ $URL: Key '$KEY' does not match expected value"
+      echo "Expected: $EXPECTED_VALUE"
+      echo "Actual: $ACTUAL_VALUE"
+      exit 1
+    fi
+  done
+}
+
+echo -e "\n\nchecking response key-value pairs:"
+check_response "http://localhost:8000/foo" '{"detail":"Not Found"}'
+check_response "http://localhost:8000/health" '{"status":"OK"}'
+check_response "http://localhost:8000/scenarios/1" '{"id":"1"}'
+check_response "http://localhost:8000/scenarios/1" '{"id":"1"}'
+
+# Check that an array contains an element with specific key-value pair
+check_array_contains() {
+  URL=$1
+  KEY=$2
+  VALUE=$3
+  RESPONSE=$(curl --silent "$URL")
+  
+  if echo "$RESPONSE" | jq -e "map(select(.$KEY == \"$VALUE\")) | length > 0" > /dev/null; then
+    echo "✅ $URL: Found array element with $KEY = '$VALUE'"
   else
-    echo ✅ "$URL": ${RESPONSE:0:15}... \(expected: "$EXPECT"\)
+    echo "❌ $URL: No array element with $KEY = '$VALUE' found"
+    echo "Expected to find element with: $KEY = $VALUE"
+    echo "Response first few elements: $(echo "$RESPONSE" | jq '.[0:2]')"
+    exit 1
   fi
 }
 
-echo -e "\n\ntesting response beginnings:"
-check_response "http://localhost:8000/foo" '{"detail":"Not Found"}'
-check_response "http://localhost:8000/health" '{"status":"OK"}'
-check_response "http://localhost:8000/tables" '{"tables":['
-check_response "http://localhost:8000/scenarios" '[{"id":1,"usage":'
-check_response "http://localhost:8000/scenarios/1" '{"id":1,"usage":'
-check_response "http://localhost:8000/organizations" '[{"name":'
-check_response "http://localhost:8000/organizations/1" '{"name":'
+echo -e "\n\nchecking that arrays contain an element with key-value pair:"
+check_array_contains "http://localhost:8000/scenarios" "time_horizon" "2035"
+check_array_contains "http://localhost:8000/organizations" "name" "World Bank Group"


### PR DESCRIPTION
📦 New CLI dependency [`jq`](https://jqlang.org/) was added to facilitate this. This can be installed (on MacOS) using `brew install jq`

This PR enhances the integration test script by adding support for validating object responses, and JSON array responses. It facilitates checking if specific key-value pairs are found _anywhere_ in the response. 

The previous tests were brittle, and depended on the JSON responses being in a specific order. 

Closes #74