### PR TITLE
ci: run all actions all the time

### DIFF
--- a/.github/workflows/api-docker-build-and-push.yml
+++ b/.github/workflows/api-docker-build-and-push.yml
@@ -6,17 +6,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'api/**'
-      - '.github/workflows/api-docker-build-and-push.yml'
-      - 'docker-compose.yml'
   pull_request:
     branches:
       - main
-    paths:
-      - 'api/**'
-      - '.github/workflows/api-docker-build-and-push.yml'
-      - 'docker-compose.yml'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/api-lint.yml
+++ b/.github/workflows/api-lint.yml
@@ -4,15 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'api/**'
-      - '.github/workflows/api-lint.yml'
   pull_request:
     branches:
       - main
-    paths:
-      - 'api/**'
-      - '.github/workflows/api-lint.yml'
   workflow_dispatch:
 jobs:
   ruff:

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -4,15 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'api/**'
-      - '.github/workflows/api-test.yml'
   pull_request:
     branches:
       - main
-    paths:
-      - 'api/**'
-      - '.github/workflows/api-test.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/db-test.yml
+++ b/.github/workflows/db-test.yml
@@ -3,15 +3,7 @@ name: Test DB service
 on:
   push:
     branches: [ main ]
-    paths:
-      - 'database/**'
-      - '.github/workflows/db-test.yml'
-      - 'docker-compose.yaml'
   pull_request:
-    paths:
-      - 'database/**'
-      - '.github/workflows/db-test.yml'
-      - 'docker-compose.yaml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -4,15 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-lint.yml'
   pull_request:
     branches:
       - main
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-lint.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -4,15 +4,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-test.yml'
   pull_request:
     branches:
       - main
-    paths:
-      - 'frontend/**'
-      - '.github/workflows/frontend-test.yml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Only triggering actions when certain files were touched was conflicting with "requiring status checks" on merges to `main`.

Reverts (most of) #95