### PR TITLE
feat(lint): enable TypeScript type-checking in ESLint configuration

### DIFF
--- a/frontend/eslint.config.ts
+++ b/frontend/eslint.config.ts
@@ -7,7 +7,7 @@ export default tseslint.config(
   {
     extends: [
       js.configs.recommended,
-      ...tseslint.configs.recommendedTypeChecked // Add type checking rules
+      ...tseslint.configs.recommendedTypeChecked, // Add type checking rules
     ],
     files: ["**/*.{ts,tsx}"],
     languageOptions: {
@@ -17,9 +17,9 @@ export default tseslint.config(
         projectService: true,
         tsconfigRootDir: "./",
       },
-      },
-      plugins: {
-      "@typescript-eslint": tseslint.plugin
+    },
+    plugins: {
+      "@typescript-eslint": tseslint.plugin,
     },
   },
 );

--- a/frontend/eslint.config.ts
+++ b/frontend/eslint.config.ts
@@ -3,13 +3,23 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", "node_modules"] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommendedTypeChecked // Add type checking rules
+    ],
     files: ["**/*.{ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2022,
       globals: globals.browser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: "./",
+      },
+      },
+      plugins: {
+      "@typescript-eslint": tseslint.plugin
     },
   },
 );

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -10,5 +10,5 @@
     "strict": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts", "eslint.config.ts", "vitest.config.ts"]
+  "include": ["vite.config.ts", "eslint.config.ts", "vitest.config.ts", "postcss.config.ts", "tailwind.config.ts"]
 }

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -10,5 +10,11 @@
     "strict": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts", "eslint.config.ts", "vitest.config.ts", "postcss.config.ts", "tailwind.config.ts"]
+  "include": [
+    "vite.config.ts",
+    "eslint.config.ts",
+    "vitest.config.ts",
+    "postcss.config.ts",
+    "tailwind.config.ts"
+  ]
 }


### PR DESCRIPTION
This PR enhances our linting capabilities by configuring ESLint to detect TypeScript type errors. Previously, ESLint was only checking for syntax and style issues.

The goal is for this to catch issues like the one solved in #110 