### PR TITLE
build(frontend): replace nginx with Azure Static Web Apps CLI

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
     build:
       context: frontend
     ports:
-      - "${PBTAR_FRONTEND_PORT:-80}:80"
+      - "${PBTAR_FRONTEND_PORT:-80}:4280"
     container_name: pbtar-frontend
 
 volumes:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -17,10 +17,13 @@ COPY . .
 RUN npm run build
 
 # Production stage
-FROM nginx:stable-alpine
+FROM node:20-slim AS production
 
 # Copy built assets from the build stage
-COPY --from=build /app/dist /usr/share/nginx/html
+COPY --from=build /app/dist /app/dist
 
-# Start nginx
-CMD ["nginx", "-g", "daemon off;"]
+# Install Azure SWA CLI globally
+RUN npm install -g @azure/static-web-apps-cli
+
+# Start SWA CLI
+CMD ["swa", "start", "app/dist", "--host", "0.0.0.0"]


### PR DESCRIPTION
This PR updates the frontend Docker container to use Azure Static Web Apps CLI instead of Nginx for serving the application. This change aligns our local development environment to be as close as possible to our production deployment platform (which will be Azure Static Web Apps).

Chiefly, this aligns with the DEV/PROD parity 12FA principle: https://12factor.net/dev-prod-parity

- Replaced Nginx with Azure Static Web Apps CLI (@azure/static-web-apps-cli)
- Modified container startup command to use swa start instead of nginx
- Updated Dockerfile to use Node.js in production stage instead of Nginx

Benefits:
- Provides built-in support for Azure Static Web Apps configuration settings
- Simplifies deployment process by using the same tooling locally and in production