### PR TITLE
Add colophon component

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,9 +6,5 @@
 .idea/
 .vscode/
 
-# Git
-.git/
-.gitignore
-
 # Other project-specific files
 *.env

--- a/.github/workflows/azure-static-web-apps-green-pebble-01f5d5c1e.yml
+++ b/.github/workflows/azure-static-web-apps-green-pebble-01f5d5c1e.yml
@@ -57,6 +57,22 @@ jobs:
               (github.event_name == 'pull_request' && format('{0}-{1}', 'pr', github.event.pull_request.number)) ||
               github.ref_name
             }}
+          VITE_GITHUB_ACTOR: ${{ github.actor }}
+          VITE_GITHUB_EVENT_NAME: ${{ github.event_name }}
+          VITE_GITHUB_REPOSITORY: ${{ github.repository }}
+          VITE_GITHUB_REF: ${{ github.ref }}
+          VITE_GITHUB_SHA: ${{ github.sha }}
+          VITE_GITHUB_HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          VITE_GITHUB_WORKFLOW: ${{ github.workflow }}
+          VITE_GITHUB_WORKFLOW_REF: ${{ github.workflow_ref }}
+          VITE_GITHUB_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          VITE_GITHUB_RUN_ID: ${{ github.run_id }}
+          VITE_GITHUB_RUN_NUMBER: ${{ github.run_number }}
+          VITE_GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          VITE_BUILD_MACHINE_NAME: ${{ runner.name }}
+          VITE_BUILD_OS: ${{ runner.os }}
+          VITE_BUILD_OS_VERSION: ${{ runner.os-version }}
+          VITE_BUILD_ARCH: ${{ runner.arch }}
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,15 @@ FROM node:24-slim AS build
 # Set working directory
 WORKDIR /app
 
+# Copy package files
+COPY package.json package-lock.json* ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy source files
+COPY . .
+
 # Copy git info from previous stage
 COPY --from=git-info /tmp/git_sha /tmp/git_sha
 COPY --from=git-info /tmp/git_branch /tmp/git_branch
@@ -21,15 +30,6 @@ COPY --from=git-info /tmp/git_status /tmp/git_status
 RUN echo "export VITE_GIT_SHA=$(cat git_sha)" >> /tmp/git_profile && \
     echo "export VITE_GIT_BRANCH=$(cat git_branch)" >> /tmp/git_profile && \
     echo "export VITE_GIT_CLEAN=$([ ! -s git_status ] && echo 'true' || echo 'false')" >> /tmp/git_profile
-
-# Copy package files
-COPY package.json package-lock.json* ./
-
-# Install dependencies
-RUN npm ci
-
-# Copy source files
-COPY . .
 
 # Source the env vars and build
 SHELL ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Git info stage
-FROM alpine/git as git-info
+FROM alpine/git:2.49.0 as git-info
 WORKDIR /app
 COPY .git ./.git
 RUN git rev-parse HEAD > /tmp/git_sha && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,13 @@
-# Git info stage
-FROM alpine/git:2.49.0 as git-info
-WORKDIR /app
-COPY . .
-
-RUN \
-  VITE_GIT_SHA="$(git rev-parse HEAD)" && \
-  VITE_GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" && \
-  GIT_STATUS="$(git status --porcelain)" && \
-  VITE_GIT_CLEAN="$( [ -z "$GIT_STATUS" ] && echo 'true' || echo 'false' )" && \
-  echo "export VITE_GIT_SHA=$VITE_GIT_SHA" >> /tmp/git_vars && \
-  echo "export VITE_GIT_BRANCH=$VITE_GIT_BRANCH" >> /tmp/git_vars && \
-  echo "export VITE_GIT_CLEAN=$VITE_GIT_CLEAN" >> /tmp/git_vars
-
 # Build stage
 FROM node:24-slim AS build
 
 # Set working directory
 WORKDIR /app
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+   git=1:2.39.* \
+ && rm -rf /var/lib/apt/lists/*
 
 # Copy package files
 COPY package.json package-lock.json* ./
@@ -27,12 +18,7 @@ RUN npm ci
 # Copy source files
 COPY . .
 
-# Copy git info from previous stage
-COPY --from=git-info /tmp/git_vars /tmp/git_vars
-
-# Source the env vars and build
-SHELL ["/bin/bash", "-c"]
-RUN source /tmp/git_vars && npm run build
+RUN npm run build
 
 # Production stage
 FROM node:24-slim AS production

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ FROM alpine/git:2.49.0 as git-info
 WORKDIR /app
 COPY . .
 COPY .git ./.git
-RUN git rev-parse HEAD > /tmp/git_sha && \
-    git rev-parse --abbrev-ref HEAD > /tmp/git_branch && \
-    git status --porcelain > /tmp/git_status
 
 RUN echo "export VITE_GIT_SHA=$(git rev-parse HEAD)" >> /tmp/git_vars && \
     echo "export VITE_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> /tmp/git_vars && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,29 @@
 # Git info stage
 FROM alpine/git as git-info
 WORKDIR /app
-COPY . .
 COPY .git ./.git
-RUN echo "export VITE_GIT_SHA=$(git rev-parse HEAD)" >> git_info && \
-    echo "export VITE_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> git_info && \
-    echo "export VITE_GIT_CLEAN=$([ -z "$(git status --porcelain)" ] && echo "true" || echo "false")" >> git_info
+RUN git rev-parse HEAD > git_sha && \
+    git rev-parse --abbrev-ref HEAD > git_branch && \
+    git status --porcelain > git_status
 
 # Build stage
 FROM node:24-slim AS build
 
 # Set working directory
 WORKDIR /app
+
+# Install git
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
+# Copy git info from previous stage
+COPY --from=git-info /app/git_sha /app/git_sha
+COPY --from=git-info /app/git_branch /app/git_branch
+COPY --from=git-info /app/git_status /app/git_status
+
+# Set git info as env vars
+RUN echo "export VITE_GIT_SHA=$(cat git_sha)" >> /etc/profile && \
+    echo "export VITE_GIT_BRANCH=$(cat git_branch)" >> /etc/profile && \
+    echo "export VITE_GIT_CLEAN=$([ ! -s git_status ] && echo 'true' || echo 'false')" >> /etc/profile
 
 # Copy package files
 COPY package.json package-lock.json* ./
@@ -22,12 +34,9 @@ RUN npm ci
 # Copy source files
 COPY . .
 
-# Copy git info from previous stage
-COPY --from=git-info /app/git_info /tmp/git_vars
-
 # Source the env vars and build
 SHELL ["/bin/bash", "-c"]
-RUN source /tmp/git_vars && npm run build
+RUN source /etc/profile && npm run build
 
 # Production stage
 FROM node:24-slim AS production

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,14 @@ WORKDIR /app
 COPY . .
 COPY .git ./.git
 
-RUN echo "export VITE_GIT_SHA=$(git rev-parse HEAD)" >> /tmp/git_vars && \
-    echo "export VITE_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> /tmp/git_vars && \
-    echo "export VITE_GIT_CLEAN=$([ ! -s $(git status --porcelain) ] && echo 'true' || echo 'false')" >> /tmp/git_vars
+RUN \
+  VITE_GIT_SHA="$(git rev-parse HEAD)" && \
+  VITE_GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" && \
+  GIT_STATUS="$(git status --porcelain)" && \
+  VITE_GIT_CLEAN="$( [ -z "$GIT_STATUS" ] && echo 'true' || echo 'false' )" && \
+  echo "export VITE_GIT_SHA=$VITE_GIT_SHA" >> /tmp/git_vars && \
+  echo "export VITE_GIT_BRANCH=$VITE_GIT_BRANCH" >> /tmp/git_vars && \
+  echo "export VITE_GIT_CLEAN=$VITE_GIT_CLEAN" >> /tmp/git_vars
 
 # Build stage
 FROM node:24-slim AS build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Git info stage
 FROM alpine/git:2.49.0 as git-info
 WORKDIR /app
+COPY . .
 COPY .git ./.git
 RUN git rev-parse HEAD > /tmp/git_sha && \
     git rev-parse --abbrev-ref HEAD > /tmp/git_branch && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,6 @@ FROM node:24-slim AS build
 # Set working directory
 WORKDIR /app
 
-# Install git
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
-
 # Copy git info from previous stage
 COPY --from=git-info /tmp/git_sha /tmp/git_sha
 COPY --from=git-info /tmp/git_branch /tmp/git_branch

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 FROM alpine/git:2.49.0 as git-info
 WORKDIR /app
 COPY . .
-COPY .git ./.git
 
 RUN \
   VITE_GIT_SHA="$(git rev-parse HEAD)" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM node:24-slim AS build
 # Set working directory
 WORKDIR /app
 
+# Install git
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
 # Copy package files
 COPY package.json package-lock.json* ./
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pbtar_frontend",
-  "version": "0.0.1.9001",
+  "version": "0.0.1.9002",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pbtar_frontend",
-      "version": "0.0.1.9001",
+      "version": "0.0.1.9002",
       "license": "MIT",
       "dependencies": {
         "lucide-react": "^0.513.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "jsdom": "^26.1.0",
         "postcss": "^8.5.4",
         "prettier": "^3.5.3",
+        "simple-git": "^3.27.0",
         "tailwindcss": "^4.1.7",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.33.1",
@@ -1236,6 +1237,23 @@
       "integrity": "sha512-9e42zjhLIxzBONroNC4SGsTqdB877tzwH2S6lqgTav9K24kWJR9vNieeMVSuyqnY8FlclH21D8wsm/tuD9WA9Q==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4604,6 +4622,22 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
+    },
+    "node_modules/simple-git": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.27.0.tgz",
+      "integrity": "sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pbtar_frontend",
-  "version": "0.0.1",
+  "version": "0.0.1.9001",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pbtar_frontend",
-      "version": "0.0.1",
+      "version": "0.0.1.9001",
       "license": "MIT",
       "dependencies": {
         "lucide-react": "^0.513.0",
@@ -20,6 +20,7 @@
         "@tailwindcss/postcss": "^4.1.8",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
+        "@types/node": "^24.0.0",
         "@types/react": "^19.1.6",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.5.1",
@@ -2058,6 +2059,16 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.0.tgz",
+      "integrity": "sha512-yZQa2zm87aRVcqDyH5+4Hv9KYgSdgwX1rFnGvpbzMaC7YAljmhBET93TPiTd3ObwTL+gSpIzPKg5BqVxdCvxKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.6",
@@ -4957,6 +4968,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pbtar_frontend",
-  "version": "0.0.1.9001",
+  "version": "0.0.1.9002",
   "type": "module",
   "description": "Front-end for the pathways-based transition assessment repository (pbtar)",
   "main": "main.jsx",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@tailwindcss/postcss": "^4.1.8",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@types/node": "^24.0.0",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "jsdom": "^26.1.0",
     "postcss": "^8.5.4",
     "prettier": "^3.5.3",
+    "simple-git": "^3.27.0",
     "tailwindcss": "^4.1.7",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.33.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pbtar_frontend",
-  "version": "0.0.1",
+  "version": "0.0.1.9001",
   "type": "module",
   "description": "Front-end for the pathways-based transition assessment repository (pbtar)",
   "main": "main.jsx",

--- a/src/components/Colophon.tsx
+++ b/src/components/Colophon.tsx
@@ -42,16 +42,27 @@ const Colophon: React.FC<ColophonProps> = ({ className = '' }) => {
   }, []);
 
   const formatInfoForCopy = () => {
+    type EnvValue = string | boolean | undefined;
+    
+    const getEnvValue = (key: string, defaultValue: string = 'N/A'): string => {
+      const value = import.meta.env[key] as EnvValue;
+      if (typeof value === 'boolean') return String(value);
+      return value?.toString() ?? defaultValue;
+    };
+
     const sections = {
       'Build Info': {
-        'App Version': import.meta.env.VITE_APP_VERSION ?? 'N/A',
-        'Git SHA': import.meta.env.VITE_GIT_SHA ?? 'N/A',
-        'Branch': import.meta.env.VITE_GIT_BRANCH ?? 'N/A',
-        'Working Directory Clean': import.meta.env.VITE_GIT_CLEAN === "true" || import.meta.env.VITE_GIT_CLEAN === true,
-        'Environment': import.meta.env.VITE_ENVIRONMENT ?? 'development',
-        'Build Time': import.meta.env.VITE_BUILD_TIME ?? 'N/A',
-        'Node Version': import.meta.env.VITE_NODE_VERSION ?? 'N/A',
-        'Vite Version': import.meta.env.VITE_VERSION ?? 'N/A'
+        'App Version': getEnvValue('VITE_APP_VERSION'),
+        'Git SHA': getEnvValue('VITE_GIT_SHA'),
+        'Branch': getEnvValue('VITE_GIT_BRANCH'),
+        'Working Directory Clean': String(
+          getEnvValue('VITE_GIT_CLEAN') === 'true' || 
+          getEnvValue('VITE_GIT_CLEAN') === 'True'
+        ),
+        'Environment': getEnvValue('VITE_ENVIRONMENT', 'development'),
+        'Build Time': getEnvValue('VITE_BUILD_TIME'),
+        'Node Version': getEnvValue('VITE_NODE_VERSION'),
+        'Vite Version': getEnvValue('VITE_VERSION')
       },
       'Runtime Info': {
         'User Agent': systemInfo.userAgent,
@@ -61,24 +72,24 @@ const Colophon: React.FC<ColophonProps> = ({ className = '' }) => {
         'Connection': systemInfo.connectionType
       },
       'GitHub Build Info': {
-        'Actor': import.meta.env.VITE_GITHUB_ACTOR ?? 'N/A',
-        'Event': import.meta.env.VITE_GITHUB_EVENT_NAME ?? 'N/A',
-        'Repository': import.meta.env.VITE_GITHUB_REPOSITORY ?? 'N/A',
-        'Ref': import.meta.env.VITE_GITHUB_REF ?? 'N/A',
-        'Merge SHA': import.meta.env.VITE_GITHUB_SHA ?? 'N/A',
-        'Head SHA': import.meta.env.VITE_GITHUB_HEAD_SHA ?? 'N/A',
-        'Workflow': import.meta.env.VITE_GITHUB_WORKFLOW ?? 'N/A',
-        'Workflow Ref': import.meta.env.VITE_GITHUB_WORKFLOW_REF ?? 'N/A',
-        'Workflow SHA': import.meta.env.VITE_GITHUB_WORKFLOW_SHA ?? 'N/A',
-        'Run ID': import.meta.env.VITE_GITHUB_RUN_ID ?? 'N/A',
-        'Run Number': import.meta.env.VITE_GITHUB_RUN_NUMBER ?? 'N/A',
-        'Run Attempt': import.meta.env.VITE_GITHUB_RUN_ATTEMPT ?? 'N/A'
+        'Actor': getEnvValue('VITE_GITHUB_ACTOR'),
+        'Event': getEnvValue('VITE_GITHUB_EVENT_NAME'),
+        'Repository': getEnvValue('VITE_GITHUB_REPOSITORY'),
+        'Ref': getEnvValue('VITE_GITHUB_REF'),
+        'Merge SHA': getEnvValue('VITE_GITHUB_SHA'),
+        'Head SHA': getEnvValue('VITE_GITHUB_HEAD_SHA'),
+        'Workflow': getEnvValue('VITE_GITHUB_WORKFLOW'),
+        'Workflow Ref': getEnvValue('VITE_GITHUB_WORKFLOW_REF'),
+        'Workflow SHA': getEnvValue('VITE_GITHUB_WORKFLOW_SHA'),
+        'Run ID': getEnvValue('VITE_GITHUB_RUN_ID'),
+        'Run Number': getEnvValue('VITE_GITHUB_RUN_NUMBER'),
+        'Run Attempt': getEnvValue('VITE_GITHUB_RUN_ATTEMPT')
       },
       'Build Machine Info': {
-        'Machine Name': import.meta.env.VITE_BUILD_MACHINE_NAME ?? 'N/A',
-        'OS': import.meta.env.VITE_BUILD_OS ?? 'N/A',
-        'OS Version': import.meta.env.VITE_BUILD_OS_VERSION ?? 'N/A',
-        'Architecture': import.meta.env.VITE_BUILD_ARCH ?? 'N/A'
+        'Machine Name': getEnvValue('VITE_BUILD_MACHINE_NAME'),
+        'OS': getEnvValue('VITE_BUILD_OS'),
+        'OS Version': getEnvValue('VITE_BUILD_OS_VERSION'),
+        'Architecture': getEnvValue('VITE_BUILD_ARCH')
       }
     };
 

--- a/src/components/Colophon.tsx
+++ b/src/components/Colophon.tsx
@@ -67,10 +67,7 @@ const Colophon: React.FC<ColophonProps> = ({ className = '' }) => {
         'App Version': getEnvValue('VITE_APP_VERSION'),
         'Git SHA': getEnvValue('VITE_GIT_SHA'),
         'Branch': getEnvValue('VITE_GIT_BRANCH'),
-        'Working Directory Clean': String(
-          getEnvValue('VITE_GIT_CLEAN') === 'true' || 
-          getEnvValue('VITE_GIT_CLEAN') === 'True'
-        ),
+        'Working Directory Clean': String(getEnvValue('VITE_GIT_CLEAN')),
         'Environment': getEnvValue('VITE_ENVIRONMENT', 'development'),
         'Build Time': getEnvValue('VITE_BUILD_TIME'),
         'Node Version': getEnvValue('VITE_NODE_VERSION'),
@@ -166,7 +163,7 @@ const Colophon: React.FC<ColophonProps> = ({ className = '' }) => {
             <li>App Version: {import.meta.env.VITE_APP_VERSION ?? 'N/A'}</li>
             <li>Git SHA: {import.meta.env.VITE_GIT_SHA ?? 'N/A'}</li>
             <li>Branch: {import.meta.env.VITE_GIT_BRANCH ?? 'N/A'}</li>
-            <li>Working Directory Clean: {String(import.meta.env.VITE_GIT_CLEAN === "true" || import.meta.env.VITE_GIT_CLEAN === true)}</li>
+            <li>Working Directory Clean: {String(import.meta.env.VITE_GIT_CLEAN)}</li>
             <li>Environment: {import.meta.env.VITE_ENVIRONMENT ?? 'development'}</li>
             <li>Build Time: {import.meta.env.VITE_BUILD_TIME ?? 'N/A'}</li>
             <li>Node Version: {import.meta.env.VITE_NODE_VERSION ?? 'N/A'}</li>

--- a/src/components/Colophon.tsx
+++ b/src/components/Colophon.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { Copy, Check } from 'lucide-react';
+import React, { useEffect, useState } from "react";
+import { Copy, Check } from "lucide-react";
 
 interface ColophonProps {
   className?: string;
@@ -22,94 +22,95 @@ interface NetworkInformation {
   };
 }
 
-const Colophon: React.FC<ColophonProps> = ({ className = '' }) => {
+const Colophon: React.FC<ColophonProps> = ({ className = "" }) => {
   const [systemInfo, setSystemInfo] = useState<SystemInfo>({
-    userAgent: 'Loading...',
-    screenResolution: 'Loading...',
-    connectionType: 'Loading...',
-    language: 'Loading...',
-    devicePixelRatio: 'Loading...'
+    userAgent: "Loading...",
+    screenResolution: "Loading...",
+    connectionType: "Loading...",
+    language: "Loading...",
+    devicePixelRatio: "Loading...",
   });
   const [copied, setCopied] = useState(false);
   const [copyError, setCopyError] = useState(false);
 
   useEffect(() => {
     const getConnectionInfo = () => {
-      if ('connection' in navigator) {
+      if ("connection" in navigator) {
         const conn = navigator as unknown as NetworkInformation;
-        const effectiveType = conn.connection?.effectiveType ?? conn.effectiveType ?? 'unknown';
+        const effectiveType =
+          conn.connection?.effectiveType ?? conn.effectiveType ?? "unknown";
         const downlink = conn.connection?.downlink ?? conn.downlink ?? 0;
         return `${effectiveType} (${downlink}Mbps)`;
       }
-      return 'Not available';
+      return "Not available";
     };
 
     setSystemInfo({
       userAgent: navigator.userAgent,
       screenResolution: `${window.innerWidth}x${window.innerHeight}`,
       connectionType: getConnectionInfo(),
-      language: navigator.language || 'N/A',
-      devicePixelRatio: `${window.devicePixelRatio}x`
+      language: navigator.language || "N/A",
+      devicePixelRatio: `${window.devicePixelRatio}x`,
     });
   }, []);
 
   const formatInfoForCopy = () => {
     type EnvValue = string | boolean | undefined;
-    
-    const getEnvValue = (key: string, defaultValue: string = 'N/A'): string => {
+
+    const getEnvValue = (key: string, defaultValue: string = "N/A"): string => {
       const value = import.meta.env[key] as EnvValue;
-      if (typeof value === 'boolean') return String(value);
+      if (typeof value === "boolean") return String(value);
       return value?.toString() ?? defaultValue;
     };
 
     const sections = {
-      'Build Info': {
-        'App Version': getEnvValue('VITE_APP_VERSION'),
-        'Git SHA': getEnvValue('VITE_GIT_SHA'),
-        'Branch': getEnvValue('VITE_GIT_BRANCH'),
-        'Working Directory Clean': String(getEnvValue('VITE_GIT_CLEAN')),
-        'Environment': getEnvValue('VITE_ENVIRONMENT', 'development'),
-        'Build Time': getEnvValue('VITE_BUILD_TIME'),
-        'Node Version': getEnvValue('VITE_NODE_VERSION'),
-        'Vite Version': getEnvValue('VITE_VERSION')
+      "Build Info": {
+        "App Version": getEnvValue("VITE_APP_VERSION"),
+        "Git SHA": getEnvValue("VITE_GIT_SHA"),
+        Branch: getEnvValue("VITE_GIT_BRANCH"),
+        "Working Directory Clean": String(getEnvValue("VITE_GIT_CLEAN")),
+        Environment: getEnvValue("VITE_ENVIRONMENT", "development"),
+        "Build Time": getEnvValue("VITE_BUILD_TIME"),
+        "Node Version": getEnvValue("VITE_NODE_VERSION"),
+        "Vite Version": getEnvValue("VITE_VERSION"),
       },
-      'Runtime Info': {
-        'User Agent': systemInfo.userAgent,
-        'Screen Resolution': systemInfo.screenResolution,
-        'Device Pixel Ratio': systemInfo.devicePixelRatio,
-        'Language': systemInfo.language,
-        'Connection': systemInfo.connectionType
+      "Runtime Info": {
+        "User Agent": systemInfo.userAgent,
+        "Screen Resolution": systemInfo.screenResolution,
+        "Device Pixel Ratio": systemInfo.devicePixelRatio,
+        Language: systemInfo.language,
+        Connection: systemInfo.connectionType,
       },
-      'GitHub Build Info': {
-        'Actor': getEnvValue('VITE_GITHUB_ACTOR'),
-        'Event': getEnvValue('VITE_GITHUB_EVENT_NAME'),
-        'Repository': getEnvValue('VITE_GITHUB_REPOSITORY'),
-        'Ref': getEnvValue('VITE_GITHUB_REF'),
-        'Merge SHA': getEnvValue('VITE_GITHUB_SHA'),
-        'Head SHA': getEnvValue('VITE_GITHUB_HEAD_SHA'),
-        'Workflow': getEnvValue('VITE_GITHUB_WORKFLOW'),
-        'Workflow Ref': getEnvValue('VITE_GITHUB_WORKFLOW_REF'),
-        'Workflow SHA': getEnvValue('VITE_GITHUB_WORKFLOW_SHA'),
-        'Run ID': getEnvValue('VITE_GITHUB_RUN_ID'),
-        'Run Number': getEnvValue('VITE_GITHUB_RUN_NUMBER'),
-        'Run Attempt': getEnvValue('VITE_GITHUB_RUN_ATTEMPT')
+      "GitHub Build Info": {
+        Actor: getEnvValue("VITE_GITHUB_ACTOR"),
+        Event: getEnvValue("VITE_GITHUB_EVENT_NAME"),
+        Repository: getEnvValue("VITE_GITHUB_REPOSITORY"),
+        Ref: getEnvValue("VITE_GITHUB_REF"),
+        "Merge SHA": getEnvValue("VITE_GITHUB_SHA"),
+        "Head SHA": getEnvValue("VITE_GITHUB_HEAD_SHA"),
+        Workflow: getEnvValue("VITE_GITHUB_WORKFLOW"),
+        "Workflow Ref": getEnvValue("VITE_GITHUB_WORKFLOW_REF"),
+        "Workflow SHA": getEnvValue("VITE_GITHUB_WORKFLOW_SHA"),
+        "Run ID": getEnvValue("VITE_GITHUB_RUN_ID"),
+        "Run Number": getEnvValue("VITE_GITHUB_RUN_NUMBER"),
+        "Run Attempt": getEnvValue("VITE_GITHUB_RUN_ATTEMPT"),
       },
-      'Build Machine Info': {
-        'Machine Name': getEnvValue('VITE_BUILD_MACHINE_NAME'),
-        'OS': getEnvValue('VITE_BUILD_OS'),
-        'OS Version': getEnvValue('VITE_BUILD_OS_VERSION'),
-        'Architecture': getEnvValue('VITE_BUILD_ARCH')
-      }
+      "Build Machine Info": {
+        "Machine Name": getEnvValue("VITE_BUILD_MACHINE_NAME"),
+        OS: getEnvValue("VITE_BUILD_OS"),
+        "OS Version": getEnvValue("VITE_BUILD_OS_VERSION"),
+        Architecture: getEnvValue("VITE_BUILD_ARCH"),
+      },
     };
 
     return Object.entries(sections)
       .map(([section, data]) => {
         const items = Object.entries(data)
           .map(([key, value]) => `${key}: ${value}`)
-          .join('\n');
+          .join("\n");
         return `### ${section} ###\n${items}`;
       })
-      .join('\n\n');
+      .join("\n\n");
   };
 
   const handleCopy = () => {
@@ -119,7 +120,7 @@ const Colophon: React.FC<ColophonProps> = ({ className = '' }) => {
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
       } catch (err) {
-        console.error('Failed to copy:', err);
+        console.error("Failed to copy:", err);
         setCopyError(true);
         setTimeout(() => setCopyError(false), 2000);
       }
@@ -160,17 +161,21 @@ const Colophon: React.FC<ColophonProps> = ({ className = '' }) => {
         <div className="mb-3">
           <h4 className="font-medium mb-1">Build Info</h4>
           <ul className="list-none text-s">
-            <li>App Version: {import.meta.env.VITE_APP_VERSION ?? 'N/A'}</li>
-            <li>Git SHA: {import.meta.env.VITE_GIT_SHA ?? 'N/A'}</li>
-            <li>Branch: {import.meta.env.VITE_GIT_BRANCH ?? 'N/A'}</li>
-            <li>Working Directory Clean: {String(import.meta.env.VITE_GIT_CLEAN)}</li>
-            <li>Environment: {import.meta.env.VITE_ENVIRONMENT ?? 'development'}</li>
-            <li>Build Time: {import.meta.env.VITE_BUILD_TIME ?? 'N/A'}</li>
-            <li>Node Version: {import.meta.env.VITE_NODE_VERSION ?? 'N/A'}</li>
-            <li>Vite Version: {import.meta.env.VITE_VERSION ?? 'N/A'}</li>
+            <li>App Version: {import.meta.env.VITE_APP_VERSION ?? "N/A"}</li>
+            <li>Git SHA: {import.meta.env.VITE_GIT_SHA ?? "N/A"}</li>
+            <li>Branch: {import.meta.env.VITE_GIT_BRANCH ?? "N/A"}</li>
+            <li>
+              Working Directory Clean: {String(import.meta.env.VITE_GIT_CLEAN)}
+            </li>
+            <li>
+              Environment: {import.meta.env.VITE_ENVIRONMENT ?? "development"}
+            </li>
+            <li>Build Time: {import.meta.env.VITE_BUILD_TIME ?? "N/A"}</li>
+            <li>Node Version: {import.meta.env.VITE_NODE_VERSION ?? "N/A"}</li>
+            <li>Vite Version: {import.meta.env.VITE_VERSION ?? "N/A"}</li>
           </ul>
         </div>
-        
+
         <div className="mb-3">
           <h4 className="font-medium mb-1">Runtime Info</h4>
           <ul className="list-none text-s">
@@ -185,28 +190,42 @@ const Colophon: React.FC<ColophonProps> = ({ className = '' }) => {
         <div className="mb-3">
           <h4 className="font-medium mb-1">GitHub Build Info</h4>
           <ul className="list-none text-s">
-            <li>Actor: {import.meta.env.VITE_GITHUB_ACTOR ?? 'N/A'}</li>
-            <li>Event: {import.meta.env.VITE_GITHUB_EVENT_NAME ?? 'N/A'}</li>
-            <li>Repository: {import.meta.env.VITE_GITHUB_REPOSITORY ?? 'N/A'}</li>
-            <li>Ref: {import.meta.env.VITE_GITHUB_REF ?? 'N/A'}</li>
-            <li>Merge SHA: {import.meta.env.VITE_GITHUB_SHA ?? 'N/A'}</li>
-            <li>Head SHA: {import.meta.env.VITE_GITHUB_HEAD_SHA ?? 'N/A'}</li>
-            <li>Workflow: {import.meta.env.VITE_GITHUB_WORKFLOW ?? 'N/A'}</li>
-            <li>Workflow Ref: {import.meta.env.VITE_GITHUB_WORKFLOW_REF ?? 'N/A'}</li>
-            <li>Workflow SHA: {import.meta.env.VITE_GITHUB_WORKFLOW_SHA ?? 'N/A'}</li>
-            <li>Run ID: {import.meta.env.VITE_GITHUB_RUN_ID ?? 'N/A'}</li>
-            <li>Run Number: {import.meta.env.VITE_GITHUB_RUN_NUMBER ?? 'N/A'}</li>
-            <li>Run Attempt: {import.meta.env.VITE_GITHUB_RUN_ATTEMPT ?? 'N/A'}</li>
+            <li>Actor: {import.meta.env.VITE_GITHUB_ACTOR ?? "N/A"}</li>
+            <li>Event: {import.meta.env.VITE_GITHUB_EVENT_NAME ?? "N/A"}</li>
+            <li>
+              Repository: {import.meta.env.VITE_GITHUB_REPOSITORY ?? "N/A"}
+            </li>
+            <li>Ref: {import.meta.env.VITE_GITHUB_REF ?? "N/A"}</li>
+            <li>Merge SHA: {import.meta.env.VITE_GITHUB_SHA ?? "N/A"}</li>
+            <li>Head SHA: {import.meta.env.VITE_GITHUB_HEAD_SHA ?? "N/A"}</li>
+            <li>Workflow: {import.meta.env.VITE_GITHUB_WORKFLOW ?? "N/A"}</li>
+            <li>
+              Workflow Ref: {import.meta.env.VITE_GITHUB_WORKFLOW_REF ?? "N/A"}
+            </li>
+            <li>
+              Workflow SHA: {import.meta.env.VITE_GITHUB_WORKFLOW_SHA ?? "N/A"}
+            </li>
+            <li>Run ID: {import.meta.env.VITE_GITHUB_RUN_ID ?? "N/A"}</li>
+            <li>
+              Run Number: {import.meta.env.VITE_GITHUB_RUN_NUMBER ?? "N/A"}
+            </li>
+            <li>
+              Run Attempt: {import.meta.env.VITE_GITHUB_RUN_ATTEMPT ?? "N/A"}
+            </li>
           </ul>
         </div>
 
         <div className="mb-3">
           <h4 className="font-medium mb-1">Build Machine Info</h4>
           <ul className="list-none text-s">
-            <li>Machine Name: {import.meta.env.VITE_BUILD_MACHINE_NAME ?? 'N/A'}</li>
-            <li>OS: {import.meta.env.VITE_BUILD_OS ?? 'N/A'}</li>
-            <li>OS Version: {import.meta.env.VITE_BUILD_OS_VERSION ?? 'N/A'}</li>
-            <li>Architecture: {import.meta.env.VITE_BUILD_ARCH ?? 'N/A'}</li>
+            <li>
+              Machine Name: {import.meta.env.VITE_BUILD_MACHINE_NAME ?? "N/A"}
+            </li>
+            <li>OS: {import.meta.env.VITE_BUILD_OS ?? "N/A"}</li>
+            <li>
+              OS Version: {import.meta.env.VITE_BUILD_OS_VERSION ?? "N/A"}
+            </li>
+            <li>Architecture: {import.meta.env.VITE_BUILD_ARCH ?? "N/A"}</li>
           </ul>
         </div>
       </div>

--- a/src/components/Colophon.tsx
+++ b/src/components/Colophon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface ColophonProps {
+  className?: string;
+}
+
+const Colophon: React.FC<ColophonProps> = ({ className = '' }) => {
+  return (
+    <div className={`text-sm text-gray-500 ${className}`}>
+      <p>Build Info:</p>
+      <ul className="list-none text-xs">
+        <li>Git SHA: {import.meta.env.VITE_GIT_SHA || 'N/A'}</li>
+        <li>Branch: {import.meta.env.VITE_GIT_BRANCH || 'N/A'}</li>
+        <li>Working Directory: {import.meta.env.VITE_GIT_CLEAN === 'true' ? 'Clean' : 'Modified'}</li>
+        <li>Environment: {import.meta.env.VITE_ENVIRONMENT || 'development'}</li>
+      </ul>
+    </div>
+  );
+};
+
+export default Colophon;

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ExternalLink, Mail } from "lucide-react";
-import Colophon from '../components/Colophon';
+import Colophon from "../components/Colophon";
 
 const AboutPage: React.FC = () => {
   return (
@@ -130,7 +130,6 @@ const AboutPage: React.FC = () => {
         <div className="mt-8">
           <Colophon />
         </div>
-
       </div>
     </div>
   );

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ExternalLink, Mail } from "lucide-react";
+import Colophon from '../components/Colophon';
 
 const AboutPage: React.FC = () => {
   return (
@@ -125,6 +126,11 @@ const AboutPage: React.FC = () => {
             Contact Us
           </a>
         </section>
+
+        <div className="mt-8">
+          <Colophon />
+        </div>
+
       </div>
     </div>
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "compilerOptions": {
+    "types": ["node"],
+    "moduleResolution": "node"
+  },
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,7 +37,11 @@ const getEnv = (key: string, defaultValue?: string): string => {
 };
 
 // Safe wrapper for git operations
-const getGitInfo = async () => {
+const getGitInfo = async (): Promise<{
+  sha: string;
+  isClean: boolean|undefined;
+  branch: string;
+}> => {
   try {
     const git = simpleGit();
     const [sha, status, branch] = await Promise.all([

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,9 +48,9 @@ const getGitInfo = async () => {
 };
 
 // Plugin to inject git information at build time
-function gitInfoPlugin(): Plugin {
+function buildInfoPlugin(): Plugin {
   return {
-    name: 'vite-plugin-git-info',
+    name: 'vite-plugin-build-info',
     async config(_, { mode }) {
       const gitInfo = await getGitInfo();
       const osInfo = getOsInfo();
@@ -58,14 +58,18 @@ function gitInfoPlugin(): Plugin {
       
       return {
         define: {
+          // Build Env
           'import.meta.env.VITE_APP_VERSION': JSON.stringify(pkgVersion),
+          'import.meta.env.VITE_NODE_VERSION': JSON.stringify(process.version),
+          'import.meta.env.VITE_VERSION': JSON.stringify(viteVersion),
+          'import.meta.env.VITE_ENVIRONMENT': JSON.stringify(mode),
+          'import.meta.env.VITE_BUILD_TIME': JSON.stringify(new Date().toISOString()),
+
+          //// Git information
           'import.meta.env.VITE_GIT_SHA': JSON.stringify(gitInfo.sha),
           'import.meta.env.VITE_GIT_CLEAN': JSON.stringify(gitInfo.isClean ? 'true' : 'false'),
           'import.meta.env.VITE_GIT_BRANCH': JSON.stringify(gitInfo.branch),
-          'import.meta.env.VITE_ENVIRONMENT': JSON.stringify(mode),
-          'import.meta.env.VITE_BUILD_TIME': JSON.stringify(new Date().toISOString()),
-          'import.meta.env.VITE_NODE_VERSION': JSON.stringify(process.version),
-          'import.meta.env.VITE_VERSION': JSON.stringify(viteVersion),
+
           // Build machine information
           'import.meta.env.VITE_BUILD_MACHINE_NAME': JSON.stringify(osInfo.hostname),
           'import.meta.env.VITE_BUILD_OS': JSON.stringify(osInfo.platform),
@@ -79,7 +83,7 @@ function gitInfoPlugin(): Plugin {
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), gitInfoPlugin()],
+  plugins: [react(), buildInfoPlugin()],
   server: {
     open: true,
     port: 3000,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,8 +5,13 @@ import os from 'os';
 import pkg from './package.json';
 
 // Safe wrapper for OS functions with proper typing
-const getOsInfo = () => {
-  const safeCall = <T>(fn: () => T, defaultValue: T): T => {
+const getOsInfo = (): {
+  hostname: string;
+  platform: string;
+  release: string;
+  arch: string;
+} => {
+  const safeCall = (fn: () => string, defaultValue: string): string => {
     try {
       return fn();
     } catch {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,11 +48,9 @@ const getGitInfo = async (): Promise<{
     const git = simpleGit();
     const [sha, status, branch] = await Promise.all([
       git.revparse(["HEAD"]).catch(() => process.env.VITE_GIT_SHA || "unknown"),
-      git
-        .status()
-        .catch(() => ({
-          isClean: () => process.env.VITE_GIT_CLEAN === "true",
-        })),
+      git.status().catch(() => ({
+        isClean: () => process.env.VITE_GIT_CLEAN === "true",
+      })),
       git
         .revparse(["--abbrev-ref", "HEAD"])
         .catch(() => process.env.VITE_GIT_BRANCH || "unknown"),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,7 +38,7 @@ function gitInfoPlugin(): Plugin {
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), gitInfoPlugin()],
   server: {
     open: true,
     port: 3000,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,7 +65,7 @@ const getGitInfo = async (): Promise<{
     // Fallback to environment variables or defaults
     return {
       sha: getEnv("VITE_GIT_SHA", "unknown"),
-      isClean: getEnv("VITE_GIT_CLEAN", null),
+      isClean: getEnv("VITE_GIT_CLEAN", "unknown"),
       branch: getEnv("VITE_GIT_BRANCH", "unknown"),
     };
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,15 @@ const getOsInfo = () => {
   } as const;
 };
 
+const getEnv = (key: string, defaultValue?: string): string => {
+  const value = (process as { env: Record<string, string | undefined> }).env?.[key];
+  if (typeof value !== 'string' || value === undefined || value.trim() === '') {
+    if (defaultValue !== undefined) return defaultValue;
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+};
+
 // Safe wrapper for git operations
 const getGitInfo = async () => {
   try {
@@ -37,7 +46,7 @@ const getGitInfo = async () => {
       isClean: status.isClean(),
       branch
     };
-  } catch (error) {
+  } catch {
     // Fallback to environment variables or defaults
     return {
       sha: process.env.VITE_GIT_SHA || 'unknown',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,40 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import { defineConfig, Plugin, version as viteVersion } from 'vite';
+import react from '@vitejs/plugin-react';
+import { simpleGit } from 'simple-git';
+import os from 'os';
+import pkg from './package.json';
+
+// Plugin to inject git information at build time
+function gitInfoPlugin(): Plugin {
+  return {
+    name: 'vite-plugin-git-info',
+    async config(_, { mode }) {
+      const git = simpleGit();
+      const sha = await git.revparse(['HEAD']);
+      const status = await git.status();
+      const isClean = status.isClean();
+      const branch = await git.revparse(['--abbrev-ref', 'HEAD']);
+      
+      return {
+        define: {
+          'import.meta.env.VITE_APP_VERSION': JSON.stringify(pkg.version),
+          'import.meta.env.VITE_GIT_SHA': JSON.stringify(sha),
+          'import.meta.env.VITE_GIT_CLEAN': JSON.stringify(isClean),
+          'import.meta.env.VITE_GIT_BRANCH': JSON.stringify(branch),
+          'import.meta.env.VITE_ENVIRONMENT': JSON.stringify(mode),
+          'import.meta.env.VITE_BUILD_TIME': JSON.stringify(new Date().toISOString()),
+          'import.meta.env.VITE_NODE_VERSION': JSON.stringify(process.version),
+          'import.meta.env.VITE_VERSION': JSON.stringify(viteVersion),
+          // Build machine information
+          'import.meta.env.VITE_BUILD_MACHINE_NAME': JSON.stringify(os.hostname()),
+          'import.meta.env.VITE_BUILD_OS': JSON.stringify(os.platform()),
+          'import.meta.env.VITE_BUILD_OS_VERSION': JSON.stringify(os.release()),
+          'import.meta.env.VITE_BUILD_ARCH': JSON.stringify(os.arch()),
+        },
+      };
+    },
+  };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig, Plugin, version as viteVersion } from 'vite';
-import react from '@vitejs/plugin-react';
-import { simpleGit } from 'simple-git';
-import os from 'os';
-import pkg from './package.json';
+import { defineConfig, Plugin, version as viteVersion } from "vite";
+import react from "@vitejs/plugin-react";
+import { simpleGit } from "simple-git";
+import os from "os";
+import pkg from "./package.json";
 
 // Safe wrapper for OS functions with proper typing
 const getOsInfo = (): {
@@ -20,16 +20,18 @@ const getOsInfo = (): {
   };
 
   return {
-    hostname: safeCall(() => os.hostname(), 'unknown'),
-    platform: safeCall(() => os.platform(), 'unknown'),
-    release: safeCall(() => os.release(), 'unknown'),
-    arch: safeCall(() => os.arch(), 'unknown')
+    hostname: safeCall(() => os.hostname(), "unknown"),
+    platform: safeCall(() => os.platform(), "unknown"),
+    release: safeCall(() => os.release(), "unknown"),
+    arch: safeCall(() => os.arch(), "unknown"),
   } as const;
 };
 
 const getEnv = (key: string, defaultValue?: string): string => {
-  const value = (process as { env: Record<string, string | undefined> }).env?.[key];
-  if (typeof value !== 'string' || value === undefined || value.trim() === '') {
+  const value = (process as { env: Record<string, string | undefined> }).env?.[
+    key
+  ];
+  if (typeof value !== "string" || value === undefined || value.trim() === "") {
     if (defaultValue !== undefined) return defaultValue;
     throw new Error(`Missing required environment variable: ${key}`);
   }
@@ -39,28 +41,34 @@ const getEnv = (key: string, defaultValue?: string): string => {
 // Safe wrapper for git operations
 const getGitInfo = async (): Promise<{
   sha: string;
-  isClean: boolean|undefined;
+  isClean: boolean | undefined;
   branch: string;
 }> => {
   try {
     const git = simpleGit();
     const [sha, status, branch] = await Promise.all([
-      git.revparse(['HEAD']).catch(() => process.env.VITE_GIT_SHA || 'unknown'),
-      git.status().catch(() => ({ isClean: () => process.env.VITE_GIT_CLEAN === 'true' })),
-      git.revparse(['--abbrev-ref', 'HEAD']).catch(() => process.env.VITE_GIT_BRANCH || 'unknown')
+      git.revparse(["HEAD"]).catch(() => process.env.VITE_GIT_SHA || "unknown"),
+      git
+        .status()
+        .catch(() => ({
+          isClean: () => process.env.VITE_GIT_CLEAN === "true",
+        })),
+      git
+        .revparse(["--abbrev-ref", "HEAD"])
+        .catch(() => process.env.VITE_GIT_BRANCH || "unknown"),
     ]);
 
     return {
       sha,
       isClean: status.isClean(),
-      branch
+      branch,
     };
   } catch {
     // Fallback to environment variables or defaults
     return {
-      sha: getEnv("VITE_GIT_SHA", 'unknown'),
+      sha: getEnv("VITE_GIT_SHA", "unknown"),
       isClean: getEnv("VITE_GIT_CLEAN", null),
-      branch: getEnv("VITE_GIT_BRANCH", 'unknown'),
+      branch: getEnv("VITE_GIT_BRANCH", "unknown"),
     };
   }
 };
@@ -68,31 +76,39 @@ const getGitInfo = async (): Promise<{
 // Plugin to inject git information at build time
 function buildInfoPlugin(): Plugin {
   return {
-    name: 'vite-plugin-build-info',
+    name: "vite-plugin-build-info",
     async config(_, { mode }) {
       const gitInfo = await getGitInfo();
       const osInfo = getOsInfo();
       const pkgVersion = (pkg as { version: string | undefined }).version;
-      
+
       return {
         define: {
           // Build Env
-          'import.meta.env.VITE_APP_VERSION': JSON.stringify(pkgVersion),
-          'import.meta.env.VITE_NODE_VERSION': JSON.stringify(process.version),
-          'import.meta.env.VITE_VERSION': JSON.stringify(viteVersion),
-          'import.meta.env.VITE_ENVIRONMENT': JSON.stringify(mode),
-          'import.meta.env.VITE_BUILD_TIME': JSON.stringify(new Date().toISOString()),
+          "import.meta.env.VITE_APP_VERSION": JSON.stringify(pkgVersion),
+          "import.meta.env.VITE_NODE_VERSION": JSON.stringify(process.version),
+          "import.meta.env.VITE_VERSION": JSON.stringify(viteVersion),
+          "import.meta.env.VITE_ENVIRONMENT": JSON.stringify(mode),
+          "import.meta.env.VITE_BUILD_TIME": JSON.stringify(
+            new Date().toISOString(),
+          ),
 
           //// Git information
-          'import.meta.env.VITE_GIT_SHA': JSON.stringify(gitInfo.sha),
-          'import.meta.env.VITE_GIT_CLEAN': JSON.stringify(gitInfo.isClean ? 'true' : 'false'),
-          'import.meta.env.VITE_GIT_BRANCH': JSON.stringify(gitInfo.branch),
+          "import.meta.env.VITE_GIT_SHA": JSON.stringify(gitInfo.sha),
+          "import.meta.env.VITE_GIT_CLEAN": JSON.stringify(
+            gitInfo.isClean ? "true" : "false",
+          ),
+          "import.meta.env.VITE_GIT_BRANCH": JSON.stringify(gitInfo.branch),
 
           // Build machine information
-          'import.meta.env.VITE_BUILD_MACHINE_NAME': JSON.stringify(osInfo.hostname),
-          'import.meta.env.VITE_BUILD_OS': JSON.stringify(osInfo.platform),
-          'import.meta.env.VITE_BUILD_OS_VERSION': JSON.stringify(osInfo.release),
-          'import.meta.env.VITE_BUILD_ARCH': JSON.stringify(osInfo.arch),
+          "import.meta.env.VITE_BUILD_MACHINE_NAME": JSON.stringify(
+            osInfo.hostname,
+          ),
+          "import.meta.env.VITE_BUILD_OS": JSON.stringify(osInfo.platform),
+          "import.meta.env.VITE_BUILD_OS_VERSION": JSON.stringify(
+            osInfo.release,
+          ),
+          "import.meta.env.VITE_BUILD_ARCH": JSON.stringify(osInfo.arch),
         },
       };
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -54,7 +54,7 @@ function buildInfoPlugin(): Plugin {
     async config(_, { mode }) {
       const gitInfo = await getGitInfo();
       const osInfo = getOsInfo();
-      const pkgVersion = pkg?.version ?? 'unknown';
+      const pkgVersion = (pkg as { version: string | undefined }).version;
       
       return {
         define: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,9 +49,9 @@ const getGitInfo = async () => {
   } catch {
     // Fallback to environment variables or defaults
     return {
-      sha: process.env.VITE_GIT_SHA || 'unknown',
-      isClean: process.env.VITE_GIT_CLEAN === 'unknown',
-      branch: process.env.VITE_GIT_BRANCH || 'unknown'
+      sha: getEnv("VITE_GIT_SHA", 'unknown'),
+      isClean: getEnv("VITE_GIT_CLEAN", null),
+      branch: getEnv("VITE_GIT_BRANCH", 'unknown'),
     };
   }
 };


### PR DESCRIPTION
Add build information to the About page. 

The general idea is that having information available (but hidden by default) to users assists us when supporting them (when they file bug reports, we can have the relevant information accessible in a copy/paste-able format)

Overall implementation structure:
* Add `Colophon` react component
* Add instance of `Colophon` to bottom of "About" page
* update `vite` build config to expose information about build environment to be passed to `Colophon` props.
* Add `git` stage to build process to collect git info at docker build time.
* Add infor about GH Actions build process as envvars

Additional notes:
* Added dependency on `@types/node` to handle typing for node's `os.` module (for build machine properties)