### PR TITLE
restrict the link to scenario detail to the "View details >" text

### DIFF
--- a/src/components/ScenarioCard.test.tsx
+++ b/src/components/ScenarioCard.test.tsx
@@ -142,7 +142,7 @@ describe("ScenarioCard component", () => {
   it("has the main container classes for styling", () => {
     const { container } = renderScenarioCard();
 
-    const link = container.querySelector("a");
+    const link = container.querySelector("div");
     expect(link).toHaveClass("bg-white");
     expect(link).toHaveClass("rounded-lg");
     expect(link).toHaveClass("shadow-md");

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -10,10 +10,7 @@ interface ScenarioCardProps {
 
 const ScenarioCard: React.FC<ScenarioCardProps> = ({ scenario }) => {
   return (
-    <Link
-      to={`/scenario/${scenario.id}`}
-      className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-300 flex flex-col h-full border border-gray-200"
-    >
+    <div className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-300 flex flex-col h-full border border-gray-200">
       <div className="p-5 flex flex-col h-full">
         <div className="mb-4">
           <h2 className="text-xl font-semibold text-gray-800 mb-2">
@@ -76,14 +73,19 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({ scenario }) => {
             </div>
           </div>
           <div className="mt-2 flex justify-end">
-            <span className="text-teal-600 text-sm font-medium flex items-center">
-              View details
-              <ChevronRight size={16} className="ml-1" />
-            </span>
+            <Link
+              to={`/scenario/${scenario.id}`}
+              className="text-teal-600 text-sm font-medium flex items-center transition-colors duration-200 hover:text-teal-300"
+            >
+              <span className="flex items-center">
+                View details
+                <ChevronRight size={16} className="ml-1" />
+              </span>
+            </Link>
           </div>
         </div>
       </div>
-    </Link>
+    </div>
   );
 };
 


### PR DESCRIPTION
- resolves #135 

Removes linking from the full scenario card and restricts the linking to just the "View details >" text.

Also had to make a minor change to the testing infrastructure because the top level element of the scenario cards is now a `<div>` not an `<a>`.