### PR TITLE
Add prod-related triggers to CI actions

### DIFF
--- a/.github/workflows/frontend-docker-build-and-push.yml
+++ b/.github/workflows/frontend-docker-build-and-push.yml
@@ -5,10 +5,14 @@ on:
     - cron: "0 3 * * *" # Nightly at 3 AM UTC
   push:
     branches:
+      - production
       - main
   pull_request:
     branches:
+      - "hotfix/**"
+      - "release/**"
       - main
+      - production
   workflow_dispatch:
 
 env:

--- a/.github/workflows/frontend-json.yml
+++ b/.github/workflows/frontend-json.yml
@@ -3,6 +3,7 @@ name: JSON validate Frontend service
 on:
   push:
     branches:
+      - production
       - main
     paths:
       - "pbtar_schema.json"
@@ -10,7 +11,10 @@ on:
       - ".github/workflows/frontend-json.yml"
   pull_request:
     branches:
+      - "hotfix/**"
+      - "release/**"
       - main
+      - production
     paths:
       - "pbtar_schema.json"
       - "src/data/scenarios_metadata.json"

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -3,10 +3,14 @@ name: Lint Frontend service
 on:
   push:
     branches:
+      - production
       - main
   pull_request:
     branches:
+      - "hotfix/**"
+      - "release/**"
       - main
+      - production
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -3,10 +3,14 @@ name: Test Frontend service
 on:
   push:
     branches:
+      - production
       - main
   pull_request:
     branches:
+      - "hotfix/**"
+      - "release/**"
       - main
+      - production
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Add triggers for PRs and pushes to `production` branch, so that checks run on `release/*` and `hotfix/*` branches

closes #130