### PR TITLE
Ci/149 gitflow actions

### DIFF
--- a/.github/workflows/gitflow-backmerge.yml
+++ b/.github/workflows/gitflow-backmerge.yml
@@ -1,5 +1,6 @@
 ---
 name: Backmerge production to main
+concurrency: backmerge-production-to-main
 
 on:
   workflow_dispatch:
@@ -7,6 +8,7 @@ on:
     types: [closed]
     branches:
       - production
+    if: github.event.pull_request.merged == true
   push:
     branches:
       - production

--- a/.github/workflows/gitflow-backmerge.yml
+++ b/.github/workflows/gitflow-backmerge.yml
@@ -1,0 +1,45 @@
+---
+name: Backmerge production to main
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [closed]
+    branches:
+      - production
+  push:
+    branches:
+      - production
+
+jobs:
+  backmerge:
+    runs-on: ubuntu-latest
+    name: backmerge
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create Pull Request
+        id: create-pr
+        run: |
+          PR_URL=$(
+            gh pr create \
+              --base main \
+              --head production \
+              --title 'Backmerge `production` to `main`' \
+              --body 'Automatic backmerge. Created by GitHub action. Triggered by closing PR #${{ github.event.number }}' \
+              --assignee RMI/pbtar  \
+              --reviewer RMI/pbtar
+            )
+          echo "pr-url=$PR_URL"
+          echo "pr-url=$PR_URL" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable Auto Merge
+        id: merge-pr
+        run: |
+          gh pr merge \
+            $PR_URL \
+            --auto \
+            --merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.create-pr.outputs.pr-url }}

--- a/.github/workflows/gitflow-check.yml
+++ b/.github/workflows/gitflow-check.yml
@@ -1,0 +1,19 @@
+---
+name: Check GitFlow branch names
+
+on:
+  pull_request:
+    branches:
+      - production
+
+jobs:
+  check_branch_name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch name
+        run: |
+          echo "Source branch: ${{ github.head_ref }}"
+          if [[ ! "${{ github.head_ref }}" =~ ^(release|hotfix)/.+$ ]]; then
+            echo "::error::Only release/* or hotfix/* branches can be merged into production"
+            exit 1
+          fi


### PR DESCRIPTION
Add github workflows for:

* Checking that PRs to production are either `release/*` or `hotfix/*` branches
* Opening a PR to `main` from `production` when there is an update (push or PR close)

Closes #149 