### PR TITLE
restrict search to data that is visible in the cards (exclude overview and expert recommendation)

### DIFF
--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -46,8 +46,6 @@ export const filterScenarios = (
         ...scenario.sectors,
         scenario.publisher,
         scenario.published_date,
-        scenario.overview,
-        scenario.expertRecommendation,
       ];
 
       return searchFields.some((field) =>


### PR DESCRIPTION
- resolves #139 

ℹ️ One can test by searching for "cooperation" or "complementing" on the [production site](https://green-pebble-01f5d5c1e.6.azurestaticapps.net) and then compare to doing the same on the [PR preview site](https://green-pebble-01f5d5c1e-175.westus2.6.azurestaticapps.net). Those words currently appear only in the "Scenario Overview" and "Expert Recommendations" sections (respectively) of the "ZETI Net Zero Pathway" metadata.