### PR TITLE
Check GH rulesets

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -3,4 +3,3 @@
 These json files represent [GitHub Rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets).
 
 Each is created by exporting an existing ruleset in effect in this repo
-

--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,6 @@
+# GitHub Rulesets
+
+These json files represent [GitHub Rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets).
+
+Each is created by exporting an existing ruleset in effect in this repo
+

--- a/.github/rulesets/gitflow-hotfix.json
+++ b/.github/rulesets/gitflow-hotfix.json
@@ -8,9 +8,7 @@
   "conditions": {
     "ref_name": {
       "exclude": [],
-      "include": [
-        "refs/heads/hotfix/**/*"
-      ]
+      "include": ["refs/heads/hotfix/**/*"]
     }
   },
   "rules": [

--- a/.github/rulesets/gitflow-hotfix.json
+++ b/.github/rulesets/gitflow-hotfix.json
@@ -1,0 +1,42 @@
+{
+  "id": 5772908,
+  "name": "gitflow-hotfix",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "RMI/pbtar",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/hotfix/**/*"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "creation"
+    },
+    {
+      "type": "update"
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 2,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/.github/rulesets/gitflow-main.json
+++ b/.github/rulesets/gitflow-main.json
@@ -1,0 +1,49 @@
+{
+  "id": 5772900,
+  "name": "gitflow-main",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "RMI/pbtar",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH",
+        "refs/heads/main"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "creation"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": false,
+        "automatic_copilot_code_review_enabled": true,
+        "allowed_merge_methods": [
+          "squash"
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/.github/rulesets/gitflow-main.json
+++ b/.github/rulesets/gitflow-main.json
@@ -8,10 +8,7 @@
   "conditions": {
     "ref_name": {
       "exclude": [],
-      "include": [
-        "~DEFAULT_BRANCH",
-        "refs/heads/main"
-      ]
+      "include": ["~DEFAULT_BRANCH", "refs/heads/main"]
     }
   },
   "rules": [
@@ -33,9 +30,7 @@
         "require_last_push_approval": true,
         "required_review_thread_resolution": false,
         "automatic_copilot_code_review_enabled": true,
-        "allowed_merge_methods": [
-          "squash"
-        ]
+        "allowed_merge_methods": ["squash"]
       }
     }
   ],

--- a/.github/rulesets/gitflow-production.json
+++ b/.github/rulesets/gitflow-production.json
@@ -8,9 +8,7 @@
   "conditions": {
     "ref_name": {
       "exclude": [],
-      "include": [
-        "refs/heads/production"
-      ]
+      "include": ["refs/heads/production"]
     }
   },
   "rules": [
@@ -32,10 +30,7 @@
         "require_last_push_approval": true,
         "required_review_thread_resolution": true,
         "automatic_copilot_code_review_enabled": false,
-        "allowed_merge_methods": [
-          "merge",
-          "squash"
-        ]
+        "allowed_merge_methods": ["merge", "squash"]
       }
     }
   ],

--- a/.github/rulesets/gitflow-production.json
+++ b/.github/rulesets/gitflow-production.json
@@ -1,0 +1,54 @@
+{
+  "id": 5772913,
+  "name": "gitflow-production",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "RMI/pbtar",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/production"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "creation"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 2,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": true,
+        "automatic_copilot_code_review_enabled": false,
+        "allowed_merge_methods": [
+          "merge",
+          "squash"
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 2,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    },
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "pull_request"
+    }
+  ]
+}

--- a/.github/rulesets/gitflow-release.json
+++ b/.github/rulesets/gitflow-release.json
@@ -1,0 +1,56 @@
+{
+  "id": 5772902,
+  "name": "gitflow-release",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "RMI/pbtar",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "refs/heads/release/**/*"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "creation"
+    },
+    {
+      "type": "update"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": true,
+        "automatic_copilot_code_review_enabled": false,
+        "allowed_merge_methods": [
+          "squash"
+        ]
+      }
+    },
+    {
+      "type": "deletion"
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 2,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/.github/rulesets/gitflow-release.json
+++ b/.github/rulesets/gitflow-release.json
@@ -8,9 +8,7 @@
   "conditions": {
     "ref_name": {
       "exclude": [],
-      "include": [
-        "refs/heads/release/**/*"
-      ]
+      "include": ["refs/heads/release/**/*"]
     }
   },
   "rules": [
@@ -32,9 +30,7 @@
         "require_last_push_approval": true,
         "required_review_thread_resolution": true,
         "automatic_copilot_code_review_enabled": false,
-        "allowed_merge_methods": [
-          "squash"
-        ]
+        "allowed_merge_methods": ["squash"]
       }
     },
     {

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -8,9 +8,7 @@
   "conditions": {
     "ref_name": {
       "exclude": [],
-      "include": [
-        "~DEFAULT_BRANCH"
-      ]
+      "include": ["~DEFAULT_BRANCH"]
     }
   },
   "rules": [
@@ -29,9 +27,7 @@
         "require_last_push_approval": false,
         "required_review_thread_resolution": false,
         "automatic_copilot_code_review_enabled": false,
-        "allowed_merge_methods": [
-          "squash"
-        ]
+        "allowed_merge_methods": ["squash"]
       }
     },
     {

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,80 @@
+{
+  "id": 4845072,
+  "name": "main",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "RMI/pbtar",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "automatic_copilot_code_review_enabled": false,
+        "allowed_merge_methods": [
+          "squash"
+        ]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "Docker actions / build-docker-image / build (linux/amd64)",
+            "integration_id": 15368
+          },
+          {
+            "context": "Docker actions / build-docker-image / merge",
+            "integration_id": 15368
+          },
+          {
+            "context": "Docker actions / hadolint / hadolint",
+            "integration_id": 15368
+          },
+          {
+            "context": "Build / Build Application",
+            "integration_id": 15368
+          },
+          {
+            "context": "Formatting / Run Prettier Check",
+            "integration_id": 15368
+          },
+          {
+            "context": "JSON Schema Validation / Run ajv JSON validator",
+            "integration_id": 15368
+          },
+          {
+            "context": "Build and Deploy Job",
+            "integration_id": 15368
+          },
+          {
+            "context": "Linting / Run ESLint",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -41,7 +41,7 @@ jobs:
           jq -rc '.[]' /tmp/ruleset_ids.json | while read ID
           do
             echo "ID=$ID"
-            gh api "/repos/RMI/pbtar/rulesets/$ID" | \
+            gh api "${{ format('/repos/{0}/rulesets', github.repository) }}/$ID" | \
             jq 'del(
               .current_user_can_bypass,
               ._links,

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -52,7 +52,6 @@ jobs:
             > "/tmp/repo_rulesets/${ID}.json"
           done
 
-
       - name: Prepare local rulesets
         run: |
 

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -54,9 +54,10 @@ jobs:
             RULESET_NAME="$(jq -rc '.name' /tmp/remote_rulesets/${ID}.json)"
             echo "RULESET_NAME=$RULESET_NAME"
             mv "/tmp/remote_rulesets/${ID}.json" "/tmp/remote_rulesets/${RULESET_NAME}.json"
-            cat "/tmp/remote_rulesets/${RULESET_NAME}.json"
-            echo ""
           done
+
+      - name: Show Remote Repo Rules
+        run: cat /tmp/remote_rulesets/*
 
 
       - name: Prepare local rulesets

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -2,7 +2,7 @@
 on:
   pull_request:
     paths:
-      - '.github/rulesets/**'
+      - ".github/rulesets/**"
   push:
     branches:
       - "hotfix/**"

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -19,11 +19,31 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Get existing Rulesets
-        id: get-rulesets
+      - name: Get all existing Rulesets from Repo
+        id: get-all-rulesets-repo
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          RULESETS="$(gh api ${{ format('/repos/{0}/rulesets', github.repository) }})"
-          echo "rulesets=$RULESETS"
-          echo "rulesets=$RULESETS" >> "$GITHUB_OUTPUT"
+          gh api ${{ format('/repos/{0}/rulesets', github.repository) }} > /tmp/all_rulesets.json
+          jq '.' /tmp/all_rulesets.json
+
+          jq '[ .[] | .id ]' /tmp/all_rulesets.json > /tmp/ruleset_ids.json
+          cat /tmp/ruleset_ids.json
+
+          RULESET_LINKS="$(jq -jc '.[] | ._links.self.href' /tmp/all_rulesets)"
+          echo "ruleset-links=$RULESET_LINKS"
+          echo "ruleset-links=$RULESET_LINKS" >> "$GITHUB_OUTPUT"
+
+      - name: Get Rulesets details from Repo
+        id: get-rulesets-details-repo
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+
+          mkdir /tmp/repo_rulesets
+          jq -rc '.[]' /tmp/ruleset_ids.json | while read ID
+          do
+            echo "ID=$ID"
+            gh api "/repos/RMI/pbtar/rulesets/$ID" | jq '.' > "/tmp/repo_rulesets/${ID}.json"
+          done

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -30,8 +30,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh api "${{ format('/repos/{0}/rulesets', github.repository) }}" | \
-          jq '.' /tmp/all_rulesets.json
+          gh api "${{ format('/repos/{0}/rulesets', github.repository) }}" > /tmp/all_rulesets.json
 
           jq '[ .[] | .id ]' /tmp/all_rulesets.json > /tmp/ruleset_ids.json
           cat /tmp/ruleset_ids.json

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -24,7 +24,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh api ${{ format('/repos/{0}/rulesets', github.repository) }} > /tmp/all_rulesets.json
+          gh api /repos/RMI/pbtar/rulesets > /tmp/all_rulesets.json
           jq '.' /tmp/all_rulesets.json
 
           jq '[ .[] | .id ]' /tmp/all_rulesets.json > /tmp/ruleset_ids.json
@@ -41,7 +41,7 @@ jobs:
           jq -rc '.[]' /tmp/ruleset_ids.json | while read ID
           do
             echo "ID=$ID"
-            gh api "${{ format('/repos/{0}/rulesets', github.repository) }}/$ID" | \
+            gh api "/repos/RMI/pbtar/rulesets/$ID" | \
             jq 'del(
               .current_user_can_bypass,
               ._links,
@@ -53,6 +53,8 @@ jobs:
             RULESET_NAME="$(jq -rc '.name' /tmp/repo_rulesets/${ID}.json)"
             echo "RULESET_NAME=$RULESET_NAME"
             mv "/tmp/repo_rulesets/${ID}.json" "/tmp/repo_rulesets/${RULESET_NAME}.json"
+            cat "/tmp/repo_rulesets/${RULESET_NAME}.json"
+            echo ""
           done
 
 

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -53,7 +53,7 @@ jobs:
             > "/tmp/remote_rulesets/${ID}.json"
             RULESET_NAME="$(jq -rc '.name' /tmp/remote_rulesets/${ID}.json)"
             echo "RULESET_NAME=$RULESET_NAME"
-            SANITIZED_RULESET_NAME="$(echo "$RULESET_NAME" | tr -c 'a-zA-Z0-9_-.' '_')"
+            SANITIZED_RULESET_NAME="$(echo "$RULESET_NAME" | tr -c 'a-zA-Z0-9.-_' '_')"
             mv "/tmp/remote_rulesets/${ID}.json" "/tmp/remote_rulesets/${SANITIZED_RULESET_NAME}.json"
           done
 
@@ -69,7 +69,7 @@ jobs:
             ID="$(jq -rc '.id' $FILE)"
             RULESET_NAME="$(jq -rc '.name' $FILE)"
             echo "$FILE: $ID, $RULESET_NAME"
-            SANITIZED_RULESET_NAME="$(echo "$RULESET_NAME" | tr -c 'a-zA-Z0-9_-.' '_')"
+            SANITIZED_RULESET_NAME="$(echo "$RULESET_NAME" | tr -c 'a-zA-Z0-9.-_' '_')"
             jq 'del(.bypass_actors)' $FILE > "/tmp/local_rulesets/${SANITIZED_RULESET_NAME}.json"
           done
 

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -30,10 +30,6 @@ jobs:
           jq '[ .[] | .id ]' /tmp/all_rulesets.json > /tmp/ruleset_ids.json
           cat /tmp/ruleset_ids.json
 
-          RULESET_LINKS="$(jq -jc '.[] | ._links.self.href' /tmp/all_rulesets)"
-          echo "ruleset-links=$RULESET_LINKS"
-          echo "ruleset-links=$RULESET_LINKS" >> "$GITHUB_OUTPUT"
-
       - name: Get Rulesets details from Repo
         id: get-rulesets-details-repo
         env:

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -41,7 +41,15 @@ jobs:
           jq -rc '.[]' /tmp/ruleset_ids.json | while read ID
           do
             echo "ID=$ID"
-            gh api "/repos/RMI/pbtar/rulesets/$ID" | jq '.' > "/tmp/repo_rulesets/${ID}.json"
+            gh api "/repos/RMI/pbtar/rulesets/$ID" | \
+            jq 'del(
+              .current_user_can_bypass,
+              ._links,
+              .node_id,
+              .created_at,
+              .updated_at
+            )' \
+            > "/tmp/repo_rulesets/${ID}.json"
           done
 
 
@@ -58,4 +66,11 @@ jobs:
 
       - name: Diff directories
         run: |
-          diff -bur /tmp/repo_rulesets/ /tmp/local_rulesets/
+
+          diff \
+            --recursive \
+            --unified \
+            --new-file \
+            --color=auto \
+            /tmp/repo_rulesets/ \
+            /tmp/local_rulesets/

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -1,0 +1,27 @@
+---
+on:
+  pull_request:
+    branches:
+      - "hotfix/**"
+      - "release/**"
+      - main
+      - production
+
+name: Rulesets Checks
+concurrency: rulesets-checks
+
+jobs:
+  build:
+    name: "Build Application"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get existing Rulesets
+        id: get-rulesets
+        run: |
+          RULESETS="$(gh api ${{ format('/repos/{0}/rulesets', github.repository) }})"
+          echo "rulesets=$RULESETS"
+          echo "rulesets=$RULESETS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -47,7 +47,8 @@ jobs:
               ._links,
               .node_id,
               .created_at,
-              .updated_at
+              .updated_at,
+              .bypass_actors
             )' \
             > "/tmp/repo_rulesets/${ID}.json"
             RULESET_NAME="$(jq -rc '.name' /tmp/repo_rulesets/${ID}.json)"
@@ -67,7 +68,7 @@ jobs:
             ID="$(jq -rc '.id' $FILE)"
             RULESET_NAME="$(jq -rc '.name' $FILE)"
             echo "$FILE: $ID, $RULESET_NAME"
-            jq '.' $FILE > "/tmp/local_rulesets/${RULESET_NAME}.json"
+            jq 'del(.bypass_actors)' $FILE > "/tmp/local_rulesets/${RULESET_NAME}.json"
           done
 
       - name: Diff directories

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Get all existing Rulesets from Repo
-        id: get-all-rulesets-repo
+      - name: Get all existing Rulesets from Remote Repo
+        id: get-all-rulesets-remote
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -30,14 +30,14 @@ jobs:
           jq '[ .[] | .id ]' /tmp/all_rulesets.json > /tmp/ruleset_ids.json
           cat /tmp/ruleset_ids.json
 
-      - name: Get Rulesets details from Repo
-        id: get-rulesets-details-repo
+      - name: Get Rulesets details from Remote Repo
+        id: get-rulesets-details-remote
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
 
-          mkdir /tmp/repo_rulesets
+          mkdir /tmp/remote_rulesets
           jq -rc '.[]' /tmp/ruleset_ids.json | while read ID
           do
             echo "ID=$ID"
@@ -50,11 +50,11 @@ jobs:
               .updated_at,
               .bypass_actors
             )' \
-            > "/tmp/repo_rulesets/${ID}.json"
-            RULESET_NAME="$(jq -rc '.name' /tmp/repo_rulesets/${ID}.json)"
+            > "/tmp/remote_rulesets/${ID}.json"
+            RULESET_NAME="$(jq -rc '.name' /tmp/remote_rulesets/${ID}.json)"
             echo "RULESET_NAME=$RULESET_NAME"
-            mv "/tmp/repo_rulesets/${ID}.json" "/tmp/repo_rulesets/${RULESET_NAME}.json"
-            cat "/tmp/repo_rulesets/${RULESET_NAME}.json"
+            mv "/tmp/remote_rulesets/${ID}.json" "/tmp/remote_rulesets/${RULESET_NAME}.json"
+            cat "/tmp/remote_rulesets/${RULESET_NAME}.json"
             echo ""
           done
 
@@ -79,5 +79,5 @@ jobs:
             --unified \
             --new-file \
             --color=auto \
-            /tmp/repo_rulesets/ \
+            /tmp/remote_rulesets/ \
             /tmp/local_rulesets/

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -1,11 +1,17 @@
 ---
 on:
   pull_request:
+    paths:
+      - '.github/rulesets/**'
+  push:
     branches:
       - "hotfix/**"
       - "release/**"
       - main
       - production
+  schedule:
+    - cron: "0 3 * * *" # Nightly at 3 AM UTC
+  workflow_dispatch:
 
 name: Rulesets Checks
 concurrency: rulesets-checks

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -50,7 +50,11 @@ jobs:
               .updated_at
             )' \
             > "/tmp/repo_rulesets/${ID}.json"
+            RULESET_NAME="$(jq -rc '.name' /tmp/repo_rulesets/${ID}.json)"
+            echo "RULESET_NAME=$RULESET_NAME"
+            mv "/tmp/repo_rulesets/${ID}.json" "/tmp/repo_rulesets/${RULESET_NAME}.json"
           done
+
 
       - name: Prepare local rulesets
         run: |
@@ -59,8 +63,9 @@ jobs:
           for FILE in .github/rulesets/*.json
           do
             ID="$(jq -rc '.id' $FILE)"
-            echo "$FILE: $ID"
-            jq '.' $FILE > "/tmp/local_rulesets/${ID}.json"
+            RULESET_NAME="$(jq -rc '.name' $FILE)"
+            echo "$FILE: $ID, $RULESET_NAME"
+            jq '.' $FILE > "/tmp/local_rulesets/${RULESET_NAME}.json"
           done
 
       - name: Diff directories

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Get existing Rulesets
         id: get-rulesets
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           RULESETS="$(gh api ${{ format('/repos/{0}/rulesets', github.repository) }})"
           echo "rulesets=$RULESETS"

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -53,7 +53,8 @@ jobs:
             > "/tmp/remote_rulesets/${ID}.json"
             RULESET_NAME="$(jq -rc '.name' /tmp/remote_rulesets/${ID}.json)"
             echo "RULESET_NAME=$RULESET_NAME"
-            mv "/tmp/remote_rulesets/${ID}.json" "/tmp/remote_rulesets/${RULESET_NAME}.json"
+            SANITIZED_RULESET_NAME="$(echo "$RULESET_NAME" | tr -c 'a-zA-Z0-9_-.' '_')"
+            mv "/tmp/remote_rulesets/${ID}.json" "/tmp/remote_rulesets/${SANITIZED_RULESET_NAME}.json"
           done
 
       - name: Show Remote Repo Rules
@@ -68,7 +69,8 @@ jobs:
             ID="$(jq -rc '.id' $FILE)"
             RULESET_NAME="$(jq -rc '.name' $FILE)"
             echo "$FILE: $ID, $RULESET_NAME"
-            jq 'del(.bypass_actors)' $FILE > "/tmp/local_rulesets/${RULESET_NAME}.json"
+            SANITIZED_RULESET_NAME="$(echo "$RULESET_NAME" | tr -c 'a-zA-Z0-9_-.' '_')"
+            jq 'del(.bypass_actors)' $FILE > "/tmp/local_rulesets/${SANITIZED_RULESET_NAME}.json"
           done
 
       - name: Diff directories

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh api /repos/RMI/pbtar/rulesets > /tmp/all_rulesets.json
+          gh api "${{ format('/repos/{0}/rulesets', github.repository) }}" | \
           jq '.' /tmp/all_rulesets.json
 
           jq '[ .[] | .id ]' /tmp/all_rulesets.json > /tmp/ruleset_ids.json
@@ -47,7 +47,7 @@ jobs:
           jq -rc '.[]' /tmp/ruleset_ids.json | while read ID
           do
             echo "ID=$ID"
-            gh api "/repos/RMI/pbtar/rulesets/$ID" | \
+            gh api "${{ format('/repos/{0}/rulesets', github.repository) }}/$ID" | \
             jq 'del(
               .current_user_can_bypass,
               ._links,

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -43,3 +43,19 @@ jobs:
             echo "ID=$ID"
             gh api "/repos/RMI/pbtar/rulesets/$ID" | jq '.' > "/tmp/repo_rulesets/${ID}.json"
           done
+
+
+      - name: Prepare local rulesets
+        run: |
+
+          mkdir /tmp/local_rulesets
+          for FILE in .github/rulesets/*.json
+          do
+            ID="$(jq -rc '.id' $FILE)"
+            echo "$FILE: $ID"
+            jq '.' $FILE > "/tmp/local_rulesets/${ID}.json"
+          done
+
+      - name: Diff directories
+        run: |
+          diff -bur /tmp/repo_rulesets/ /tmp/local_rulesets/

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -11,8 +11,8 @@ name: Rulesets Checks
 concurrency: rulesets-checks
 
 jobs:
-  build:
-    name: "Build Application"
+  rulesets:
+    name: "Check GH rulesets"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -59,7 +59,6 @@ jobs:
       - name: Show Remote Repo Rules
         run: cat /tmp/remote_rulesets/*
 
-
       - name: Prepare local rulesets
         run: |
 


### PR DESCRIPTION
* adds a (non-standard) `.github/rulesets` directory, with JSON exports of the existing rulesets on this repository.
* Also adds a GH workflow to check that the rulesets in effect in the repo are the same as defined in `.github/rulesets`

Predecessor to #181 and #178

NOTE: THE GH action runs using the `github.token` for authentication, which does NOT grant it information about users who can bypass rulesets:

> Note: To prevent leaking sensitive information, the bypass_actors property is only returned if the user making the API request has write access to the ruleset.
> https://docs.github.com/en/enterprise-server@3.13/rest/repos/rules?apiVersion=2022-11-28

To work around this, this action ignores the `bypass_actors` property in both the remote and local files (filtered using `jq 'del()`)