### PR TITLE
Use Updated docker action to allow forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,3 +30,7 @@ jobs:
     uses: RMI-PACTA/actions/.github/workflows/docker.yml@main
     with:
       do-check-r-sysdeps: false
+      # dependabot forks the repo when making PRs, and doesn't have access
+      # to secrets (like the deploy key) in actions. This allows the CI to
+      # pass for dependabot PRs if the build succeeds.
+      push-image: ${{ github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
Make use of the newly updated action in RMI-PACTA/actions, whic allows building the docker image, but not pushing, to disable pushing images to the registry from dependabot PRs (which fail, since it doesn't have permissions)

Closes #192 