### PR TITLE
fix: remove package version from colophon

### DIFF
--- a/src/components/Colophon.tsx
+++ b/src/components/Colophon.tsx
@@ -65,7 +65,6 @@ const Colophon: React.FC<ColophonProps> = ({ className = "" }) => {
 
     const sections = {
       "Build Info": {
-        "App Version": getEnvValue("VITE_APP_VERSION"),
         "Git SHA": getEnvValue("VITE_GIT_SHA"),
         "Branch": getEnvValue("VITE_GIT_BRANCH"),
         "Working Directory Clean": String(getEnvValue("VITE_GIT_CLEAN")),
@@ -164,7 +163,6 @@ const Colophon: React.FC<ColophonProps> = ({ className = "" }) => {
         <div className="mb-3">
           <h4 className="font-medium mb-1">Build Info</h4>
           <ul className="list-none text-s">
-            <li>App Version: {import.meta.env.VITE_APP_VERSION ?? "N/A"}</li>
             <li>Git SHA: {import.meta.env.VITE_GIT_SHA ?? "N/A"}</li>
             <li>Branch: {import.meta.env.VITE_GIT_BRANCH ?? "N/A"}</li>
             <li>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,6 @@ import { defineConfig, Plugin, version as viteVersion } from "vite";
 import react from "@vitejs/plugin-react";
 import { simpleGit } from "simple-git";
 import os from "os";
-import pkg from "./package.json";
 
 // Safe wrapper for OS functions with proper typing
 const getOsInfo = (): {
@@ -78,12 +77,10 @@ function buildInfoPlugin(): Plugin {
     async config(_, { mode }) {
       const gitInfo = await getGitInfo();
       const osInfo = getOsInfo();
-      const pkgVersion = (pkg as { version: string | undefined }).version;
 
       return {
         define: {
           // Build Env
-          "import.meta.env.VITE_APP_VERSION": JSON.stringify(pkgVersion),
           "import.meta.env.VITE_NODE_VERSION": JSON.stringify(process.version),
           "import.meta.env.VITE_VERSION": JSON.stringify(viteVersion),
           "import.meta.env.VITE_ENVIRONMENT": JSON.stringify(mode),


### PR DESCRIPTION
in #201, we introduced semantic-release, which manages and communicates application version through git tags, and only updates `package.json` upon release (usually distribution to `npm`).

Since this leaves the version string in `package.json` as the placeholder for most cases in-repo, it's not appropriate to communicate that string to users any more.

Will follow up later with a better mechanism to replace this.

Relates to #201 