### PR TITLE
Update temperature schema

### DIFF
--- a/pbtar_schema.json
+++ b/pbtar_schema.json
@@ -48,9 +48,12 @@
         "description": "Target year of the scenario",
         "type": "string"
       },
-      "target_temperature": {
-        "description": "Target temperature of the scenario",
-        "type": "string"
+      "modeled_temperature_increase": {
+        "description": "Modeled temperature increase expected by the scenario (in degrees Celsius)",
+        "type": ["number", "null"],
+        "multipleOf": 0.1,
+        "minimum": 0.5,
+        "maximum": 3
       },
       "ssp": {
         "description": "Shared Socioeconomic Pathways (SSP) associated with the scenario",
@@ -264,7 +267,6 @@
       "category",
       "category_tooltip",
       "target_year",
-      "target_temperature",
       "regions",
       "sectors",
       "publisher",

--- a/pbtar_schema.json
+++ b/pbtar_schema.json
@@ -50,7 +50,7 @@
       },
       "modeled_temperature_increase": {
         "description": "Modeled temperature increase expected by the scenario (in degrees Celsius)",
-        "type": ["number", "null"],
+        "type": "number",
         "multipleOf": 0.1,
         "minimum": 0.5,
         "maximum": 3

--- a/src/components/FilterDropdown.tsx
+++ b/src/components/FilterDropdown.tsx
@@ -1,23 +1,23 @@
 import React, { useState, useRef, useEffect } from "react";
 import { ChevronDown, X } from "lucide-react";
 
-interface FilterDropdownProps {
+interface FilterDropdownProps<T extends string | number> {
   label: string;
-  options: string[];
-  selectedValue: string | null;
-  onChange: (value: string | null) => void;
+  options: T[];
+  selectedValue: T | null;
+  onChange: (value: T | null) => void;
 }
 
-const FilterDropdown: React.FC<FilterDropdownProps> = ({
+const FilterDropdown = <T extends string | number>({
   label,
   options,
   selectedValue,
   onChange,
-}) => {
+}: FilterDropdownProps<T>) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  const handleSelect = (option: string) => {
+  const handleSelect = (option: T) => {
     onChange(option === selectedValue ? null : option);
     setIsOpen(false);
   };
@@ -56,8 +56,8 @@ const FilterDropdown: React.FC<FilterDropdownProps> = ({
             : "text-rmigray-700 bg-white border-neutral-300 hover:bg-neutral-100"
         } transition-colors duration-150`}
       >
-        <span>{selectedValue || label}</span>
-        {selectedValue ? (
+        <span>{selectedValue != null ? String(selectedValue) : label}</span>
+        {selectedValue !== null ? (
           <X
             size={16}
             className="ml-2 text-rmigray-500 hover:text-rmigray-700"
@@ -75,7 +75,7 @@ const FilterDropdown: React.FC<FilterDropdownProps> = ({
         <div className="absolute z-10 mt-1 w-full bg-white rounded-md shadow-lg border border-neutral-200 py-1 max-h-60 overflow-auto">
           {options.map((option) => (
             <div
-              key={option}
+              key={String(option)}
               onClick={() => handleSelect(option)}
               className={`px-4 py-2 text-sm cursor-pointer ${
                 option === selectedValue
@@ -83,7 +83,7 @@ const FilterDropdown: React.FC<FilterDropdownProps> = ({
                   : "text-rmigray-700 hover:bg-neutral-100"
               }`}
             >
-              {option}
+              {String(option)}
             </div>
           ))}
         </div>

--- a/src/components/ScenarioCard.test.tsx
+++ b/src/components/ScenarioCard.test.tsx
@@ -69,7 +69,9 @@ describe("ScenarioCard component", () => {
 
     expect(screen.getByText(mockScenario.target_year)).toBeInTheDocument();
     expect(
-      screen.getByText(mockScenario.modeled_temperature_increase?.toString() + "°C"),
+      screen.getByText(
+        mockScenario.modeled_temperature_increase?.toString() + "°C",
+      ),
     ).toBeInTheDocument();
   });
 

--- a/src/components/ScenarioCard.test.tsx
+++ b/src/components/ScenarioCard.test.tsx
@@ -15,7 +15,7 @@ describe("ScenarioCard component", () => {
     category_tooltip:
       "Policy scenarios focus on regulatory and legislative measures.",
     target_year: "2050",
-    target_temperature: "1.5°C",
+    modeled_temperature_increase: 1.5,
     regions: ["Global", "Europe", "North America", "Asia"],
     sectors: [
       { name: "Power", tooltip: "Electricity generation and distribution" },
@@ -69,7 +69,7 @@ describe("ScenarioCard component", () => {
 
     expect(screen.getByText(mockScenario.target_year)).toBeInTheDocument();
     expect(
-      screen.getByText(mockScenario.target_temperature),
+      screen.getByText(mockScenario.modeled_temperature_increase?.toString() + "°C"),
     ).toBeInTheDocument();
   });
 
@@ -140,7 +140,7 @@ describe("ScenarioCard component", () => {
       category: "IAM",
       category_tooltip: "Category tooltip",
       target_year: "2050",
-      target_temperature: "1.5C",
+      modeled_temperature_increase: 1.5,
       regions: ["Global", "EU", "Americas", "Africa", "Asia Pacific"], // 5 regions
       sectors: [
         { name: "Power", tooltip: "Power tooltip" },
@@ -248,7 +248,7 @@ describe("ScenarioCard search highlighting", () => {
     category: "Policy",
     category_tooltip: "Policy scenarios focus on regulatory measures.",
     target_year: "2050",
-    target_temperature: "1.5°C",
+    modeled_temperature_increase: 1.5,
     regions: ["Global", "Europe", "North America", "Hidden Match Region"],
     sectors: [
       { name: "Power", tooltip: "Electricity generation" },

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -140,10 +140,12 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
               text={highlightTextIfSearchMatch(scenario.target_year)}
               variant="year"
             />
-            <Badge
-              text={highlightTextIfSearchMatch(scenario.target_temperature)}
-              variant="temperature"
-            />
+            {scenario.modeled_temperature_increase && (
+              <Badge
+                text={highlightTextIfSearchMatch(`${scenario.modeled_temperature_increase}°C`)}
+                variant="temperature"
+              />
+            )}
           </div>
         </div>
 

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -142,7 +142,9 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
             />
             {scenario.modeled_temperature_increase && (
               <Badge
-                text={highlightTextIfSearchMatch(`${scenario.modeled_temperature_increase}°C`)}
+                text={highlightTextIfSearchMatch(
+                  `${scenario.modeled_temperature_increase}°C`,
+                )}
                 variant="temperature"
               />
             )}

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -143,7 +143,7 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
             {scenario.modeled_temperature_increase && (
               <Badge
                 text={highlightTextIfSearchMatch(
-                  `${scenario.modeled_temperature_increase}°C`,
+                  `${scenario.modeled_temperature_increase.toString()}°C`,
                 )}
                 variant="temperature"
               />

--- a/src/components/SearchSection.test.tsx
+++ b/src/components/SearchSection.test.tsx
@@ -14,7 +14,7 @@ vi.mock("../data/scenariosData", () => ({
       category: "Policy",
       category_tooltip: "Policy scenarios focus on regulatory measures.",
       target_year: "2050",
-      target_temperature: "1.5°C",
+      modeled_temperature_increase: 1.5,
       regions: ["Global", "Europe"],
       sectors: [
         { name: "Power", tooltip: "Electricity generation and distribution" },
@@ -37,7 +37,7 @@ vi.mock("../data/scenariosData", () => ({
       category: "Forecast",
       category_tooltip: "Forecast scenarios are based on existing trends.",
       target_year: "2030",
-      target_temperature: "2.7°C",
+      modeled_temperature_increase: 2.7,
       regions: ["Global", "Asia"],
       sectors: [
         {
@@ -78,7 +78,7 @@ describe("SearchSection", () => {
 
     expect(screen.getByText("Category")).toBeInTheDocument();
     expect(screen.getByText("Target Year")).toBeInTheDocument();
-    expect(screen.getByText("Temperature")).toBeInTheDocument();
+    expect(screen.getByText("Temperature (°C)")).toBeInTheDocument();
     expect(screen.getByText("Region")).toBeInTheDocument();
     expect(screen.getByText("Sector")).toBeInTheDocument();
   });

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -14,7 +14,7 @@ import {
 interface SearchSectionProps {
   filters: SearchFilters;
   scenariosNumber: number;
-  onFilterChange: (key: keyof SearchFilters, value: string | null) => void;
+  onFilterChange: <T extends string | number | null>(key: keyof SearchFilters, value: T | null) => void;
   onSearch: () => void;
   onClear: () => void;
 }
@@ -33,7 +33,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({
     new Set(scenariosData.map((d) => d.target_year)),
   ).sort() as YearTarget[];
   const temperatures: TemperatureTarget[] = Array.from(
-    new Set(scenariosData.map((d) => d.target_temperature)),
+    new Set(scenariosData.map((d) => d.modeled_temperature_increase)),
   ).sort() as TemperatureTarget[];
   const regions: Region[] = Array.from(
     new Set(scenariosData.map((d) => d.regions).flat()),
@@ -47,7 +47,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({
       filters.region ||
       filters.sector ||
       filters.target_year ||
-      filters.target_temperature) !== null;
+      filters.modeled_temperature_increase) !== null;
 
   return (
     <div className="bg-white">
@@ -61,35 +61,35 @@ const SearchSection: React.FC<SearchSectionProps> = ({
       </div>
 
       <div className="flex flex-wrap gap-2">
-        <FilterDropdown
+        <FilterDropdown<string>
           label="Category"
           options={categories}
           selectedValue={filters.category}
           onChange={(value) => onFilterChange("category", value)}
         />
 
-        <FilterDropdown
+        <FilterDropdown<string>
           label="Target Year"
           options={years}
           selectedValue={filters.target_year}
           onChange={(value) => onFilterChange("target_year", value)}
         />
 
-        <FilterDropdown
-          label="Temperature"
+        <FilterDropdown<number>
+          label="Temperature (°C)"
           options={temperatures}
-          selectedValue={filters.target_temperature}
-          onChange={(value) => onFilterChange("target_temperature", value)}
+          selectedValue={filters.modeled_temperature_increase}
+          onChange={(value) => onFilterChange("modeled_temperature_increase", value)}
         />
 
-        <FilterDropdown
+        <FilterDropdown<string>
           label="Region"
           options={regions}
           selectedValue={filters.region}
           onChange={(value) => onFilterChange("region", value)}
         />
 
-        <FilterDropdown
+        <FilterDropdown<string>
           label="Sector"
           options={sectors}
           selectedValue={filters.sector}

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -14,7 +14,10 @@ import {
 interface SearchSectionProps {
   filters: SearchFilters;
   scenariosNumber: number;
-  onFilterChange: <T extends string | number | null>(key: keyof SearchFilters, value: T | null) => void;
+  onFilterChange: <T extends string | number | null>(
+    key: keyof SearchFilters,
+    value: T | null,
+  ) => void;
   onSearch: () => void;
   onClear: () => void;
 }
@@ -79,7 +82,9 @@ const SearchSection: React.FC<SearchSectionProps> = ({
           label="Temperature (°C)"
           options={temperatures}
           selectedValue={filters.modeled_temperature_increase}
-          onChange={(value) => onFilterChange("modeled_temperature_increase", value)}
+          onChange={(value) =>
+            onFilterChange("modeled_temperature_increase", value)
+          }
         />
 
         <FilterDropdown<string>

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -17,17 +17,44 @@ An example scenario metadata JSON file looks like...
     "name": "ZETI Net Zero Pathway",
     "description": "A comprehensive pathway for the global energy sector to reach net zero by 2050",
     "category": "IAM",
+    "category_tooltip": "Integrated Assessment Model",
     "target_year": "2050",
-    "target_temperature": "1.5C",
+    "modeled_temperature_increase": 1.5,
     "regions": ["Global"],
     "sectors": [
-      "Power",
-      "Oil & Gas",
-      "Coal",
-      "Renewables",
-      "Transport",
-      "Buildings",
-      "Industrial"
+      {
+        "name": "Power Generation",
+        "tooltip": "Electricity generation and distribution",
+        "technologies": ["Solar", "Wind", "Nuclear", "Coal"]
+      },
+      {
+        "name": "Transport",
+        "tooltip": "Transportation and logistics",
+        "technologies": [
+          "Electric Vehicles",
+          "Hydrogen Vehicles",
+          "Biofuels",
+          "Public Transport",
+          "Active Mobility",
+          "Aviation Efficiency",
+          "Maritime Efficiency"
+        ]
+      },
+      {
+        "name": "Buildings",
+        "tooltip": "Residential and commercial buildings",
+        "technologies": ["Energy Efficiency", "Heat Pumps", "Other"]
+      },
+      {
+        "name": "Industrial",
+        "tooltip": "Manufacturing and industrial processes",
+        "technologies": [
+          "Electrification",
+          "Carbon Capture and Storage",
+          "Hydrogen Use",
+          "Other"
+        ]
+      }
     ],
     "publisher": "Zero Emissions Technology Institute",
     "published_date": "2021-05-18",
@@ -98,8 +125,9 @@ new_scenario_metadata <-
       name = "ZETI Net Zero Pathway",
       description = "Text based description short",
       category = "IAM",
+      category_tooltip = "Integrated Assessment Model",
       target_year = "2050",
-      target_temperature = "1.5C",
+      modeled_temperature_increase = 1.5,
       regions = list("Global"),
       sectors = list("Power", "Oil & Gas", "Coal", "Renewables", "Transport", "Buildings", "Industrial"),
       publisher = "Zero Emissions Technology Institute",
@@ -127,8 +155,9 @@ new_scenario_metadata <-
       name = list("ZETI Net Zero Pathway"),
       description = "Text based description short",
       category = "IAM",
+      category_tooltip = "Integrated Assessment Model",
       target_year = "2050",
-      target_temperature = "1.5C",
+      modeled_temperature_increase = 1.5,
       regions = "Global",
       sectors = list("Poer", "Oil&Gas", "Coal", "Renewables", "Transport", "Buildings", "Industrial"),
       publisher = "Zero Emissions Technology Institute",

--- a/src/data/scenarios_metadata_1.json
+++ b/src/data/scenarios_metadata_1.json
@@ -6,7 +6,7 @@
     "category": "IAM",
     "category_tooltip": "Integrated Assessment Model",
     "target_year": "2050",
-    "target_temperature": "1.5C",
+    "modeled_temperature_increase": 1.5,
     "regions": ["Global"],
     "sectors": [
       {

--- a/src/data/scenarios_metadata_2.json
+++ b/src/data/scenarios_metadata_2.json
@@ -6,7 +6,7 @@
     "category": "IAM",
     "category_tooltip": "Integrated Assessment Model",
     "target_year": "2050",
-    "target_temperature": "3C",
+    "modeled_temperature_increase": 3,
     "regions": ["Global", "EU", "SEA", "Americas", "Asia Pacific"],
     "sectors": [
       {

--- a/src/data/scenarios_metadata_3.json
+++ b/src/data/scenarios_metadata_3.json
@@ -6,7 +6,7 @@
     "category": "NDC",
     "category_tooltip": "Nationally Determined Contribution",
     "target_year": "2050",
-    "target_temperature": "1.5C",
+    "modeled_temperature_increase": 1.5,
     "regions": ["SEA"],
     "sectors": [
       {

--- a/src/data/scenarios_metadata_4.json
+++ b/src/data/scenarios_metadata_4.json
@@ -6,7 +6,7 @@
     "category": "ITR",
     "category_tooltip": "Implied Temperature Rise",
     "target_year": "2060",
-    "target_temperature": "2C",
+    "modeled_temperature_increase": 2,
     "regions": ["Global", "SEA", "Asia Pacific"],
     "sectors": [
       {

--- a/src/data/scenarios_metadata_5.json
+++ b/src/data/scenarios_metadata_5.json
@@ -6,7 +6,7 @@
     "category": "NDC",
     "category_tooltip": "Nationally Determined Contribution",
     "target_year": "2040",
-    "target_temperature": "1.5C",
+    "modeled_temperature_increase": 1.5,
     "regions": ["EU"],
     "sectors": [
       {

--- a/src/data/scenarios_metadata_6.json
+++ b/src/data/scenarios_metadata_6.json
@@ -6,7 +6,7 @@
     "category": "IAM",
     "category_tooltip": "Integrated Assessment Model",
     "target_year": "2100",
-    "target_temperature": "1.5C",
+    "modeled_temperature_increase": 1.5,
     "regions": ["Global"],
     "sectors": [
       {

--- a/src/data/scenarios_metadata_7.json
+++ b/src/data/scenarios_metadata_7.json
@@ -6,7 +6,7 @@
     "category": "ITR",
     "category_tooltip": "Implied Temperature Rise",
     "target_year": "2050",
-    "target_temperature": "2C",
+    "modeled_temperature_increase": 2,
     "regions": ["Global", "EU", "Americas", "Asia Pacific"],
     "sectors": [
       {

--- a/src/data/scenarios_metadata_8.json
+++ b/src/data/scenarios_metadata_8.json
@@ -6,7 +6,7 @@
     "category": "ITR",
     "category_tooltip": "Implied Temperature Rise",
     "target_year": "2050",
-    "target_temperature": "2C",
+    "modeled_temperature_increase": 2,
     "regions": ["Global", "EU", "Americas", "Asia Pacific"],
     "sectors": [
       {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -87,7 +87,7 @@ const HomePage: React.FC = () => {
 
   const handleFilterChange = <T extends string | number>(
     key: keyof SearchFilters,
-    value: T | null
+    value: T | null,
   ) => {
     setFilters((prev) => ({ ...prev, [key]: value }));
   };

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -17,7 +17,7 @@ const HomePage: React.FC = () => {
   const [filters, setFilters] = useState<SearchFilters>({
     category: null,
     target_year: null,
-    target_temperature: null,
+    modeled_temperature_increase: null,
     region: null,
     sector: null,
     searchTerm: "",
@@ -41,8 +41,8 @@ const HomePage: React.FC = () => {
         filters.searchTerm !== prevFiltersRef.current.searchTerm ||
         filters.category !== prevFiltersRef.current.category ||
         filters.target_year !== prevFiltersRef.current.target_year ||
-        filters.target_temperature !==
-          prevFiltersRef.current.target_temperature ||
+        filters.modeled_temperature_increase !==
+          prevFiltersRef.current.modeled_temperature_increase ||
         filters.region !== prevFiltersRef.current.region ||
         filters.sector !== prevFiltersRef.current.sector;
 
@@ -85,9 +85,9 @@ const HomePage: React.FC = () => {
     };
   }, [isSticky]);
 
-  const handleFilterChange = (
+  const handleFilterChange = <T extends string | number>(
     key: keyof SearchFilters,
-    value: string | null,
+    value: T | null
   ) => {
     setFilters((prev) => ({ ...prev, [key]: value }));
   };
@@ -100,7 +100,7 @@ const HomePage: React.FC = () => {
     setFilters({
       category: null,
       target_year: null,
-      target_temperature: null,
+      modeled_temperature_increase: null,
       region: null,
       sector: null,
       searchTerm: "",

--- a/src/pages/ScenarioDetailPage.tsx
+++ b/src/pages/ScenarioDetailPage.tsx
@@ -88,10 +88,12 @@ const ScenarioDetailPage: React.FC = () => {
               text={scenario.target_year}
               variant="year"
             />
-            <Badge
-              text={scenario.target_temperature}
-              variant="temperature"
-            />
+            {scenario.modeled_temperature_increase && (
+              <Badge
+                text={`${scenario.modeled_temperature_increase}°C`}
+                variant="temperature"
+              />
+            )}
           </div>
 
           <div className="flex flex-col sm:flex-row sm:justify-between text-sm">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,7 @@ export interface Scenario {
   category: string;
   category_tooltip: string;
   target_year: string;
-  target_temperature: string;
+  modeled_temperature_increase?: number;
   regions: string[];
   sectors: {
     name: Sector;
@@ -24,7 +24,7 @@ export interface Scenario {
 
 export type ScenarioCategory = "IAM" | "ITR" | "NDC" | "Other";
 
-export type TemperatureTarget = "1.5C" | "2C" | "2.5C" | "3C" | "4C" | "N/A";
+export type TemperatureTarget = number;
 
 export type YearTarget =
   | "2030"
@@ -58,7 +58,7 @@ export type Sector =
 export interface SearchFilters {
   category: ScenarioCategory | null;
   target_year: YearTarget | null;
-  target_temperature: TemperatureTarget | null;
+  modeled_temperature_increase: TemperatureTarget | null;
   region: Region | null;
   sector: Sector | null;
   searchTerm: string;

--- a/src/utils/searchUtils.test.tsx
+++ b/src/utils/searchUtils.test.tsx
@@ -13,7 +13,7 @@ describe("searchUtils", () => {
       category: "Policy",
       category_tooltip: "Policy scenarios focus on regulatory measures.",
       target_year: "2050",
-      target_temperature: "1.5°C",
+      modeled_temperature_increase: 1.5,
       regions: ["Global", "Europe"],
       sectors: [
         { name: "Power", tooltip: "Electricity generation and distribution" },
@@ -36,7 +36,7 @@ describe("searchUtils", () => {
       category: "Forecast",
       category_tooltip: "Forecast scenarios are based on existing trends.",
       target_year: "2030",
-      target_temperature: "2.7°C",
+      modeled_temperature_increase: 2.7,
       regions: ["Global", "Asia"],
       sectors: [
         {
@@ -82,8 +82,8 @@ describe("searchUtils", () => {
       expect(result[0].id).toBe("scenario-2");
     });
 
-    it("filters by target temperature", () => {
-      const filters: SearchFilters = { target_temperature: "1.5°C" };
+    it("filters by modeled temperature increase", () => {
+      const filters: SearchFilters = { modeled_temperature_increase: 1.5 };
       const result = filterScenarios(mockScenarios, filters);
 
       expect(result.length).toBe(1);

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -17,8 +17,8 @@ export const filterScenarios = (
 
     // Target temperature filter
     if (
-      filters.target_temperature &&
-      scenario.target_temperature !== filters.target_temperature
+      filters.modeled_temperature_increase &&
+      scenario.modeled_temperature_increase !== filters.modeled_temperature_increase
     ) {
       return false;
     }
@@ -44,7 +44,7 @@ export const filterScenarios = (
         scenario.description,
         scenario.category,
         scenario.target_year,
-        scenario.target_temperature,
+        scenario.modeled_temperature_increase,
         ...scenario.regions,
         ...scenario.sectors.map((s) => s.name),
         ...scenario.sectors.map((s) => s.tooltip || ""),

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -18,7 +18,8 @@ export const filterScenarios = (
     // Target temperature filter
     if (
       filters.modeled_temperature_increase &&
-      scenario.modeled_temperature_increase !== filters.modeled_temperature_increase
+      scenario.modeled_temperature_increase !==
+        filters.modeled_temperature_increase
     ) {
       return false;
     }


### PR DESCRIPTION
Potentially closes #136 

* rename `target_temperature` to `modeled_temperature_increase`
* change temperature type from `string` to `number` in the schema
* update components to work with numeric temperature and the new name

NOTE: during this PR I realized that the README in data grew out of sync with the schema. I created an issue about it #224. Since I am not familiar with the R helper functions mentioned there I leave it to someone else to update those preferably.

@lloyd-rmi is this the change that you were seeking in #136 ?