### PR TITLE
ci: Disable GH comments on sucessful release

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
       [
         "@semantic-release/github",
         {
+          "successComment": false,
           "assets": [
             {
               "path": "dist/*.tgz",


### PR DESCRIPTION
setting `successComment` to false disables commenting on related issues and PRs, but that is failing here, as `repository` is showing as undefined in the logs. The feature is a nice to have, but not worth fretting over at this point.