### PR TITLE
Fix/256 tooltip search

### DIFF
--- a/src/utils/searchUtils.test.tsx
+++ b/src/utils/searchUtils.test.tsx
@@ -242,7 +242,7 @@ describe("searchUtils", () => {
   });
 });
 
-describe("searchUtils", () => {
+describe("searchUtils - array results", () => {
   //
   // Mock scenario data
   const regions: string[] = [

--- a/src/utils/searchUtils.test.tsx
+++ b/src/utils/searchUtils.test.tsx
@@ -241,3 +241,89 @@ describe("searchUtils", () => {
     });
   });
 });
+
+describe("searchUtils", () => {
+  //
+  // Mock scenario data
+  const regions: string[] = [
+    "Global",
+    "EU",
+    "Americas",
+    "Asia Pacific",
+    "SEA",
+    "Country-Specific",
+  ];
+
+  const sectors: string[] = [
+    "Land Use",
+    "Agriculture",
+    "Real Estate",
+    "Industry",
+    "Steel",
+    "Cement",
+    "Chemicals",
+    "Coal Mining",
+    "Oil (Upstream)",
+    "Gas (Upstream)",
+    "Power",
+    "Transport",
+    "Road transport",
+    "Aviation",
+    "Rail",
+    "Shipping",
+    "Other",
+  ];
+
+  const mockScenarios: Scenario[] = [
+    {
+      id: "scenario-full-arrays",
+      name: "Scenario with Full Arrays of Enums",
+      description:
+        "A scenario that includes all possible enum values for testing purposes.",
+      pathwayType: "Policy",
+      regions: [
+        "Global",
+        "EU",
+        "Americas",
+        "Asia Pacific",
+        "SEA",
+        "Country-Specific",
+      ],
+      sectors: sectors.map((sector) => ({ name: sector })),
+      publisher: "IEA",
+      publicationYear: "Jan 2023",
+      overview: "Mock overview",
+      expertRecommendation: "Mock recommendation",
+      dataSource: {
+        description: "Mock Data Source",
+        url: "https://example.com/data-source",
+        downloadAvailable: true,
+      },
+    },
+  ];
+
+  //These tests are to ensure that search works for all array values, even when
+  //they would not be surface directly in the UI (e.g. "Power, Transport, + 15
+  //more")
+  describe("filterScenarios for many array values", () => {
+    regions.forEach((region) => {
+      it(`options for regions - ${region}`, () => {
+        const filters: SearchFilters = { region: region };
+        const result = filterScenarios(mockScenarios, filters);
+
+        expect(result.length).toBe(1);
+        expect(result[0].id).toBe("scenario-full-arrays");
+      });
+    });
+
+    sectors.forEach((sector) => {
+      it(`filters by sector - ${sector}`, () => {
+        const filters: SearchFilters = { sector: sector };
+        const result = filterScenarios(mockScenarios, filters);
+
+        expect(result.length).toBe(1);
+        expect(result[0].id).toBe("scenario-full-arrays");
+      });
+    });
+  });
+});

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -1,5 +1,4 @@
 import { Scenario, SearchFilters } from "../types";
-import { getSectorTooltip } from "../utils/tooltipUtils";
 
 export const filterScenarios = (
   scenarios: Scenario[],
@@ -51,7 +50,6 @@ export const filterScenarios = (
         scenario.modelTempIncrease,
         ...scenario.regions,
         ...scenario.sectors.map((s) => s.name),
-        ...scenario.sectors.map((s) => getSectorTooltip(s.name) || ""),
         scenario.publisher,
         scenario.publicationYear,
       ];


### PR DESCRIPTION
Closes #256 

Removes static tooltip string from search, and adds test to ensure all values in large arrays (which trigger "+n more" in the scenario cards) still return search results.