### PR TITLE
Fix/261 end crash on search

### DIFF
--- a/src/components/HighlightedText.tsx
+++ b/src/components/HighlightedText.tsx
@@ -11,19 +11,26 @@ const HighlightedText: React.FC<HighlightedTextProps> = ({
   searchTerm,
   className = "",
 }) => {
-  if (!searchTerm.trim()) {
-    return <span className={className}>{text}</span>;
+  // Normalize inputs to ensure consistent behavior
+  const normalizedText = String(text ?? "");
+  const normalizedTerm = String(searchTerm ?? "");
+
+  if (!normalizedTerm.trim()) {
+    return <span className={className}>{normalizedText}</span>;
   }
 
   // Split text by the search term (case-insensitive)
-  const parts = text.split(
-    new RegExp(`(${searchTerm.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "gi"),
+  const parts = normalizedText.split(
+    new RegExp(
+      `(${normalizedTerm.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`,
+      "gi",
+    ),
   );
 
   return (
     <span className={className}>
       {parts.map((part, i) =>
-        part.toLowerCase() === searchTerm.toLowerCase() ? (
+        part.toLowerCase() === normalizedTerm.toLowerCase() ? (
           <mark
             key={i}
             className="bg-energy-100 text-energy-800 px-0.5 rounded-sm font-medium"

--- a/src/components/ScenarioCard.test.tsx
+++ b/src/components/ScenarioCard.test.tsx
@@ -449,8 +449,9 @@ describe("tooltip functionality", () => {
     it("does not crash when highlighting numeric fields", () => {
       const s: Scenario = {
         ...baseScenario,
-        modelYearEnd: 2030 as any, // number on purpose
-        publicationYear: 2024 as any, // number
+        // Using a double cast to satisfy TS, but this still presents as numeric at runtime.
+        modelYearEnd: 2030 as unknown as string, // number on purpose
+        publicationYear: 2024 as unknown as string, // number
       };
 
       expect(() => renderWithRouter(s, "2030")).not.toThrow();
@@ -466,8 +467,9 @@ describe("tooltip functionality", () => {
     it("does not crash with null / undefined text fields", () => {
       const s: Scenario = {
         ...baseScenario,
-        description: null as any,
-        publisher: undefined as any,
+        // Using a double cast to satisfy TS, but this still presents as null/undefined at runtime.
+        description: null as unknown as string, // null
+        publisher: undefined as unknown as string, // undefined
       };
 
       expect(() => renderWithRouter(s, "rmi")).not.toThrow();
@@ -479,7 +481,11 @@ describe("tooltip functionality", () => {
     });
 
     it("highlights matches inside stringified numbers", () => {
-      const s: Scenario = { ...baseScenario, modelYearEnd: 2045 as any };
+      const s: Scenario = {
+        ...baseScenario,
+        // Using a double cast to satisfy TS, but this still presents as null/undefined at runtime.
+        modelYearEnd: 2045 as unknown as string, // number on purpose
+      };
       const { container } = renderWithRouter(s, "2045");
       const marks = container.querySelectorAll("mark");
       expect(Array.from(marks).some((m) => m.textContent === "2045")).toBe(

--- a/src/components/ScenarioCard.test.tsx
+++ b/src/components/ScenarioCard.test.tsx
@@ -414,4 +414,77 @@ describe("tooltip functionality", () => {
       expect.stringContaining("cursor-help"),
     );
   });
+
+  describe("ScenarioCard robustness with non-string values", () => {
+    const baseScenario: Scenario = {
+      id: "robust-1",
+      name: "Scenario A",
+      description: "Desc",
+      pathwayType: "Policy",
+      modelYearEnd: "2030",
+      modelTempIncrease: 1.5,
+      regions: ["EU", "US"],
+      sectors: [{ name: "Power" }],
+      publisher: "RMI",
+      publicationYear: "2024",
+      overview: "x",
+      expertRecommendation: "x",
+      dataSource: {
+        description: "x",
+        url: "https://example.com",
+        downloadAvailable: false,
+      },
+    };
+
+    const renderWithRouter = (scenario: Scenario, searchTerm = "") =>
+      render(
+        <MemoryRouter>
+          <ScenarioCard
+            scenario={scenario}
+            searchTerm={searchTerm}
+          />
+        </MemoryRouter>,
+      );
+
+    it("does not crash when highlighting numeric fields", () => {
+      const s: Scenario = {
+        ...baseScenario,
+        modelYearEnd: 2030 as any, // number on purpose
+        publicationYear: 2024 as any, // number
+      };
+
+      expect(() => renderWithRouter(s, "2030")).not.toThrow();
+      // Should render stringified year and highlight it
+      expect(screen.getByText("2030")).toBeInTheDocument();
+      // mark exists for the numeric match (adjust selector if your Highlighter differs)
+      const marked = document.querySelectorAll("mark");
+      expect(Array.from(marked).some((m) => m.textContent === "2030")).toBe(
+        true,
+      );
+    });
+
+    it("does not crash with null / undefined text fields", () => {
+      const s: Scenario = {
+        ...baseScenario,
+        description: null as any,
+        publisher: undefined as any,
+      };
+
+      expect(() => renderWithRouter(s, "rmi")).not.toThrow();
+      // Card chrome still there
+      expect(screen.getByText("Pathway type:")).toBeInTheDocument();
+      expect(screen.getByText("Publisher:")).toBeInTheDocument();
+      // No “[object Object]” leaks
+      expect(document.body.textContent).not.toContain("[object Object]");
+    });
+
+    it("highlights matches inside stringified numbers", () => {
+      const s: Scenario = { ...baseScenario, modelYearEnd: 2045 as any };
+      const { container } = renderWithRouter(s, "2045");
+      const marks = container.querySelectorAll("mark");
+      expect(Array.from(marks).some((m) => m.textContent === "2045")).toBe(
+        true,
+      );
+    });
+  });
 });

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -91,7 +91,10 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
   );
 
   // Helper function to conditionally highlight text based on search term
-  const highlightTextIfSearchMatch = (text: string) => {
+  const highlightTextIfSearchMatch = (value: unknown) => {
+    // If value is null or undefined, return empty string, otherwise cast to string.
+    const text = value == null ? "" : String(value);
+
     // If there's a search term and it matches the text
     if (searchTerm && text.toLowerCase().includes(searchTerm.toLowerCase())) {
       return (

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -91,7 +91,9 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
   );
 
   // Helper function to conditionally highlight text based on search term
-  const highlightTextIfSearchMatch = (value: unknown) => {
+  const highlightTextIfSearchMatch = (
+    value: string | number | undefined | null | boolean,
+  ) => {
     // If value is null or undefined, return empty string, otherwise cast to string.
     const text = value == null ? "" : String(value);
 


### PR DESCRIPTION
Re-enables search (including highlighting). 

Problem arose in #252 when several scenario fields (`modelYearEnd`, for example) changed from `string` to `number`, but the search functionality was still treating everything as a string (`toLowerCase` works fine on strings, but causes the error we saw when called on a number).

Closes #261 