### PR TITLE
build(chore): Suppress ExperimentalWarning (type stripping)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@vitejs/plugin-react": "^5.0.1",
         "autoprefixer": "^10.4.21",
         "conventional-changelog-conventionalcommits": "^9.1.0",
+        "cross-env": "^10.0.0",
         "eslint": "^9.33.0",
         "globals": "^16.3.0",
         "jiti": "^2.5.1",
@@ -516,6 +517,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.5",
@@ -3723,6 +3731,24 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "main.jsx",
   "scripts": {
     "dev": "vite",
-    "build": "vite build --mode ${VITE_BUILD_MODE:-development}",
+    "build": "cross-env NODE_OPTIONS=--disable-warning=ExperimentalWarning vite build --mode ${VITE_BUILD_MODE:-development}",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -37,6 +37,7 @@
     "@vitejs/plugin-react": "^5.0.1",
     "autoprefixer": "^10.4.21",
     "conventional-changelog-conventionalcommits": "^9.1.0",
+    "cross-env": "^10.0.0",
     "eslint": "^9.33.0",
     "globals": "^16.3.0",
     "jiti": "^2.5.1",


### PR DESCRIPTION
To this point, we've seen an `ExperimentalWarning` about `Type Stripping is an experimental feature`. While not troublesome, it has been somewhat noisy, and this disables that warning during the build process.

Introduces `cross-env` dependency, to not worry about altering script if anyone wants to work on a windows machine.

Closes #167