### PR TITLE
ci(schema): only format on `public/` on schema render

### DIFF
--- a/scripts/generate-schema-docs.sh
+++ b/scripts/generate-schema-docs.sh
@@ -11,7 +11,7 @@ generate-schema-doc \
   public/ \
   public/ 
 
-npm run format
+prettier --write public/
 
 # leave the venv
 deactivate


### PR DESCRIPTION
Running `prettier` against the whole project (`npm run format`) make CI checks about schema docs overly sensitive to other, unrelated, `prettier` warnings. This now only runs against the rendered files.

Closes #265