### PR TITLE
HOTFIX: `v1.0.0` immediate issues

### DIFF
--- a/.github/workflows/gitflow-backmerge.yml
+++ b/.github/workflows/gitflow-backmerge.yml
@@ -27,9 +27,7 @@ jobs:
               --base main \
               --head production \
               --title 'Backmerge `production` to `main`' \
-              --body 'Automatic backmerge. Created by GitHub action. Triggered by closing PR #${{ github.event.number }}' \
-              --assignee RMI/pbtar  \
-              --reviewer RMI/pbtar
+              --body 'Automatic backmerge. Created by GitHub action. Triggered by closing PR #${{ github.event.number }}'
             )
           echo "pr-url=$PR_URL"
           echo "pr-url=$PR_URL" >> $GITHUB_OUTPUT

--- a/src/components/EnvironmentBanner.tsx
+++ b/src/components/EnvironmentBanner.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 
 const EnvironmentBanner: React.FC = () => {
-  const environment: string = import.meta.env.VITE_BUILD_MODE || "development";
+  const environment: string = (import.meta.env.VITE_BUILD_MODE || "development")
+    .trim()
+    .toLowerCase();
 
   if (environment === "production") {
     return null;


### PR DESCRIPTION
Note to reviewers: The "Check GitFlow Names" action is expected to fail, since this is a `hotfix/` branch, and that is currently configured to expect only `next` branches. Tracking at #322, but should not block this.

----

Backmerge action was failing on `production`, since it did not receive permissions to access the `organization.teams` keys it was using to request and assign reviewers. Removing the request should allow action to run without issues.

Closes #309

----

The build machine was passing an envvar `VITE_BUILD_MODE` with newlines
appended. Sanitizing the string before comparion.

Closes #307 