### PR TITLE
ci(concurrency): specify concurrency group at event/action level

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -18,7 +18,7 @@ on:
 
 name: Node Package Checks
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.event_action }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
the previous `$workflow`-`$ref` concurrency group caused issues in busy "merge to main" situations, by cancelling runs that were triggered by closing PRs. It also clobbered previous release actions on `main`.

This PR should resolve the first behavior (keep "closing" trigger runs active), but will still resolve many rapid pushes to main within the same release (see
https://github.com/RMI/pbtar/releases/tag/v1.1.0-dev.14, which includes 3 PRs that were merged in rapid sequence).

Followup, relates to #350