### PR TITLE
ci(rulesets): Change permissions to bypass changes to `next` to PR-only

### DIFF
--- a/.github/rulesets/gitflow-next.json
+++ b/.github/rulesets/gitflow-next.json
@@ -40,12 +40,12 @@
     {
       "actor_id": 2,
       "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
+      "bypass_mode": "pull_request"
     },
     {
       "actor_id": 5,
       "actor_type": "RepositoryRole",
-      "bypass_mode": "always"
+      "bypass_mode": "pull_request"
     }
   ]
 }


### PR DESCRIPTION
Closes #391

update ruleset to only allow bypass on ruleset for `next` from WebUI (cannot bypass rules from `git` CLI, i.e. `git push --force`)

See:
https://docs.github.com/en/enterprise-cloud@latest/admin/enforcing-policies/enforcing-policies-for-your-enterprise/enforcing-policies-for-code-governance