### PR TITLE
build(semantic-release): Checkout tags when building from branch

### DIFF
--- a/.github/workflows/node-semantic_release.yml
+++ b/.github/workflows/node-semantic_release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          fetch-tags: true
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
unless all tags are explicitly included in checkout (clone), they will not be available for inspection by `semantic-release`