### PR TITLE
fix(env banner): Update color/env matching in env banner

### DIFF
--- a/.github/workflows/node-semantic_release-pr.yml
+++ b/.github/workflows/node-semantic_release-pr.yml
@@ -62,10 +62,7 @@ jobs:
         env:
           VITE_BUILD_MODE: |
             ${{
-              ((github.event_name == 'push' && github.ref_name == 'production') && 'production') ||
-              ((github.event_name == 'push' && github.ref_name == 'main') && 'development') ||
               (github.event_name == 'push' && github.ref_name) ||
-              ((github.event_name == 'pull_request' && github.ref_name == 'next') && 'staging') ||
               (github.event_name == 'pull_request' && format('{0}-{1}', 'pr', github.event.pull_request.number)) ||
               github.ref_name
             }}

--- a/.github/workflows/node-semantic_release.yml
+++ b/.github/workflows/node-semantic_release.yml
@@ -35,10 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VITE_BUILD_MODE: |
             ${{
-              ((github.event_name == 'push' && github.ref_name == 'production') && 'production') ||
-              ((github.event_name == 'push' && github.ref_name == 'main') && 'development') ||
               (github.event_name == 'push' && github.ref_name) ||
-              ((github.event_name == 'pull_request' && github.ref_name == 'next') && 'staging') ||
               (github.event_name == 'pull_request' && format('{0}-{1}', 'pr', github.event.pull_request.number)) ||
               github.ref_name
             }}

--- a/src/components/EnvironmentBanner.tsx
+++ b/src/components/EnvironmentBanner.tsx
@@ -7,10 +7,14 @@ const EnvironmentBanner: React.FC = () => {
   if (isProd) return null; // hide on real prod builds
 
   function getBgColor(mode: string): string {
-    if (mode.startsWith("develop")) {
-      return "bg-red-500";
-    } else if (mode.startsWith("staging")) {
+    if (mode === "main") {
+      return "bg-green-500";
+    } else if (mode === "next") {
       return "bg-yellow-500";
+    } else if (mode.startsWith("hotfix")) {
+      return "bg-orange-500";
+    } else if (mode.startsWith("develop")) {
+      return "bg-red-500";
     } else if (mode.startsWith("pr-")) {
       return "bg-indigo-500";
     } else {


### PR DESCRIPTION
Add support fort `main`, `next`, and `hotfix/*` environments (set with `VITE_BUILD_MODE`), drop support for unused `staging`.

semi-strictly (trim + lowercase) match `main` and `next` build modes, everything else is `startsWith` checked.

closes #333

Note to reviewers: there isn't much to see here, since this is largely dependent on the actual build environment, which isn't easily testable