### PR TITLE
Fix/metric badges

### DIFF
--- a/src/components/Badge.test.tsx
+++ b/src/components/Badge.test.tsx
@@ -131,6 +131,14 @@ describe("Badge component", () => {
     expect(badge).toHaveClass("border-solar-200");
   });
 
+  it("applies metric styling when variant is 'metric'", () => {
+    const { container } = render(<Badge variant="metric">Intensity</Badge>);
+    const badge = container.firstChild as HTMLElement;
+    expect(badge).toHaveClass("bg-rmipurple-100");
+    expect(badge).toHaveClass("text-rmipurple-800");
+    expect(badge).toHaveClass("border-rmipurple-200");
+  });
+
   it("always includes base badge styling", () => {
     // Testing that common styles are applied to all variants
     const { container } = render(

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -39,6 +39,8 @@ const Badge: React.FC<BadgeProps> = ({
         return "bg-pinishgreen-100 text-pinishgreen-800 border-pinishgreen-200";
       case "sector":
         return "bg-solar-100 text-solar-800 border-solar-200";
+      case "metric":
+        return "bg-rmipurple-100 text-rmipurple-800 border-rmipurple-200";
       default:
         return "bg-rmigray-100 text-rmigray-800 border-rmigray-200";
     }

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -213,7 +213,7 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
         <div className="mb-3">
           <p className="text-xs font-medium text-rmigray-500 mb-1">Sectors:</p>
           <div
-            ref={geographyContainerRef}
+            ref={sectorsContainerRef}
             flex
             flex-wrap
           >
@@ -231,6 +231,11 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
         {/* Sectors section with dynamic badge count */}
         <div className="mb-3">
           <p className="text-xs font-medium text-rmigray-500 mb-1">Benchmark Metrics:</p>
+          <div
+            ref={sectorsContainerRef}
+            flex
+            flex-wrap
+          >
           <BadgeArray
             visibleCount={visibleMetricCount}
             variant="metric"
@@ -239,6 +244,7 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
           >
             {scenario.metric}
           </BadgeArray>
+          </div>
         </div>
 
         <div className="mt-auto pt-3 border-t border-gray-100">

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -197,8 +197,7 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
           </p>
           <div
             ref={geographyContainerRef}
-            flex
-            flex-wrap
+            classname="flex flex-wrap"
           >
             <BadgeArray
               variant={sortedGeography.map(
@@ -218,8 +217,7 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
           <p className="text-xs font-medium text-rmigray-500 mb-1">Sectors:</p>
           <div
             ref={sectorsContainerRef}
-            flex
-            flex-wrap
+            classname="flex flex-wrap"
           >
             <BadgeArray
               visibleCount={visibleSectorsCount}
@@ -232,15 +230,14 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
           </div>
         </div>
 
-        {/* Sectors section with dynamic badge count */}
+        {/* Metrics section with dynamic badge count */}
         <div className="mb-3">
           <p className="text-xs font-medium text-rmigray-500 mb-1">
             Benchmark Metrics:
           </p>
           <div
-            ref={sectorsContainerRef}
-            flex
-            flex-wrap
+            ref={metricContainerRef}
+            classname="flex flex-wrap"
           >
             <BadgeArray
               visibleCount={visibleMetricCount}

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -13,7 +13,7 @@ import { Scenario, PathwayType } from "../types";
 import { ChevronRight } from "lucide-react";
 import HighlightedText from "./HighlightedText";
 import { prioritizeMatches, prioritizeGeographies } from "../utils/sortUtils";
-import { getPathwayTypeTooltip, getSectorTooltip } from "../utils/tooltipUtils";
+import { getPathwayTypeTooltip, getSectorTooltip, getMetricTooltip } from "../utils/tooltipUtils";
 
 interface ScenarioCardProps {
   scenario: Scenario;
@@ -87,10 +87,12 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
   // Refs for the container elements
   const geographyContainerRef = useRef<HTMLDivElement>(null);
   const sectorsContainerRef = useRef<HTMLDivElement>(null);
+  const metricContainerRef = useRef<HTMLDivElement>(null);
 
   // Calculate how many badges can fit in each container
   const geographyBadgeWidth = 90; // Estimated average width of a geography badge in pixels
   const sectorBadgeWidth = 80; // Estimated average width of a sector badge in pixels
+  const metricBadgeWidth = 80; // Estimated average width of a metric badge in pixels
 
   const visibleGeographyCount = useAvailableBadgeCount(
     geographyContainerRef,
@@ -99,6 +101,10 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
   const visibleSectorsCount = useAvailableBadgeCount(
     sectorsContainerRef,
     sectorBadgeWidth,
+  );
+  const visibleMetricCount = useAvailableBadgeCount(
+    metricContainerRef,
+    metricBadgeWidth,
   );
 
   // Helper function to conditionally highlight text based on search term
@@ -207,6 +213,19 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
             renderLabel={(label) => highlightTextIfSearchMatch(label)}
           >
             {sortedSectors.map((sector) => sector.name)}
+          </BadgeArray>
+        </div>
+
+        {/* Sectors section with dynamic badge count */}
+        <div className="mb-3">
+          <p className="text-xs font-medium text-rmigray-500 mb-1">Benchmark Metrics:</p>
+          <BadgeArray
+            visibleCount={visibleMetricCount}
+            variant="metric"
+            tooltipGetter={getMetricTooltip}
+            renderLabel={(label) => highlightTextIfSearchMatch(label)}
+          >
+            {scenario.metric}
           </BadgeArray>
         </div>
 

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -13,7 +13,11 @@ import { Scenario, PathwayType } from "../types";
 import { ChevronRight } from "lucide-react";
 import HighlightedText from "./HighlightedText";
 import { prioritizeMatches, prioritizeGeographies } from "../utils/sortUtils";
-import { getPathwayTypeTooltip, getSectorTooltip, getMetricTooltip } from "../utils/tooltipUtils";
+import {
+  getPathwayTypeTooltip,
+  getSectorTooltip,
+  getMetricTooltip,
+} from "../utils/tooltipUtils";
 
 interface ScenarioCardProps {
   scenario: Scenario;
@@ -230,20 +234,22 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
 
         {/* Sectors section with dynamic badge count */}
         <div className="mb-3">
-          <p className="text-xs font-medium text-rmigray-500 mb-1">Benchmark Metrics:</p>
+          <p className="text-xs font-medium text-rmigray-500 mb-1">
+            Benchmark Metrics:
+          </p>
           <div
             ref={sectorsContainerRef}
             flex
             flex-wrap
           >
-          <BadgeArray
-            visibleCount={visibleMetricCount}
-            variant="metric"
-            tooltipGetter={getMetricTooltip}
-            renderLabel={(label) => highlightTextIfSearchMatch(label)}
-          >
-            {scenario.metric}
-          </BadgeArray>
+            <BadgeArray
+              visibleCount={visibleMetricCount}
+              variant="metric"
+              tooltipGetter={getMetricTooltip}
+              renderLabel={(label) => highlightTextIfSearchMatch(label)}
+            >
+              {scenario.metric}
+            </BadgeArray>
           </div>
         </div>
 

--- a/src/pages/ScenarioDetailPage.tsx
+++ b/src/pages/ScenarioDetailPage.tsx
@@ -13,7 +13,11 @@ import {
   sortGeographiesForDetails,
 } from "../utils/geographyUtils";
 import { ExternalLink, ArrowLeft } from "lucide-react";
-import { getPathwayTypeTooltip, getSectorTooltip } from "../utils/tooltipUtils";
+import {
+  getPathwayTypeTooltip,
+  getSectorTooltip,
+  getMetricTooltip,
+} from "../utils/tooltipUtils";
 
 const ScenarioDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -187,7 +191,7 @@ const ScenarioDetailPage: React.FC = () => {
                 </BadgeArray>
               </div>
 
-              <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-4">
+              <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-4 mb-6">
                 <h3 className="text-lg font-medium text-rmigray-800 mb-3">
                   Sectors
                 </h3>
@@ -203,6 +207,18 @@ const ScenarioDetailPage: React.FC = () => {
                     {scenario.sectors.map((sector) => sector.name)}
                   </BadgeArray>
                 </div>
+              </div>
+
+              <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-4 mb-6">
+                <h3 className="text-lg font-medium text-rmigray-800 mb-3">
+                  Benchmark Metrics
+                </h3>
+                <BadgeArray
+                  variant="metric"
+                  tooltipGetter={getMetricTooltip}
+                >
+                  {scenario.metric}
+                </BadgeArray>
               </div>
             </div>
           </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,14 @@ export type Sector =
   | "Agriculture"
   | "N/A";
 
+export type Metric =
+  | "Emissions Intensity"
+  | "Capacity"
+  | "Generation"
+  | "Technology Mix"
+  | "Absolute Emissions"
+  | "Carbon Price";
+
 export interface SearchFilters {
   pathwayType: PathwayType | null;
   modelYearEnd: YearTarget | null;

--- a/src/utils/tooltipUtils.ts
+++ b/src/utils/tooltipUtils.ts
@@ -1,4 +1,4 @@
-import { PathwayType, Sector } from "../types";
+import { PathwayType, Sector, Metric } from "../types";
 
 export const pathwayTypeTooltips: Record<PathwayType, string> = {
   "Direct Policy":
@@ -36,6 +36,21 @@ export const sectorTooltips: Record<Sector, string> = {
   "Transport": "Logistics of passengers and cargo.",
 };
 
+export const metricTooltips: Record<string, string> = {
+  "Emissions Intensity":
+    "Amount of greenhouse gases emitted per unit of physical output. Indicates how low-carbon the output production is",
+  "Capacity":
+    "The maximum output a power plant or energy source can produce under ideal conditions, measured in GW",
+  "Generation":
+    "The actual amount of electricity produced over a specific period, typically measured in TWh",
+  "Technology Mix":
+    "The breakdown of energy sources used for electricity generation (e.g., coal, solar, wind, nuclear). Reflects the diversity and sustainability of the energy portfolio",
+  "Absolute Emissions":
+    "Total greenhouse gas emissions produced, regardless of output. Measured in metric tons of CO₂ equivalent",
+  "Carbon Price":
+    "The cost assigned to emitting one ton of CO₂, used to incentivize lower emissions through market mechanisms or taxes",
+};
+
 export const unknownTooltip = "No tooltip available.";
 
 export const getPathwayTypeTooltip = (type: PathwayType): string => {
@@ -44,4 +59,8 @@ export const getPathwayTypeTooltip = (type: PathwayType): string => {
 
 export const getSectorTooltip = (sector: Sector): string => {
   return sectorTooltips[sector] || unknownTooltip;
+};
+
+export const getMetricTooltip = (metric: Metric): string => {
+  return metricTooltips[metric] || unknownTooltip;
 };


### PR DESCRIPTION
Add badges for metrics.

using the `rmipurple` color family (repeated from `pathwayType`) for now, but need to add more colors to the css definition.

Depends on #406

Closes #398 
Closes #359