### PR TITLE
PBTAR-25: Feat/214 badge layout

### DIFF
--- a/src/components/BadgeArray.test.tsx
+++ b/src/components/BadgeArray.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import BadgeArray from "./BadgeArray";
 
 describe("BadgeArray", () => {
@@ -74,5 +74,229 @@ describe("BadgeArray", () => {
       // @ts-expect-error children must be scalar
       render(<BadgeArray>{["A", <span key="x">X</span>]}</BadgeArray>),
     ).toThrow(/children must be string \| number \| null \| undefined/);
+  });
+});
+
+// --- Helpers for layout simulation in jsdom (typed, lint-safe) ---
+const ORIG_RECTS = new WeakMap<HTMLElement, () => DOMRect>();
+function setContainerWidth(container: HTMLElement, width: number) {
+  const orig = container.getBoundingClientRect.bind(container);
+  ORIG_RECTS.set(container, orig);
+  container.getBoundingClientRect = () =>
+    ({ left: 0, right: width, width, top: 0, bottom: 0 }) as DOMRect;
+}
+
+function restoreContainerWidth(container: HTMLElement) {
+  const orig = ORIG_RECTS.get(container);
+  if (orig) container.getBoundingClientRect = orig;
+}
+
+/** Force rows by stubbing offsetTop on wrapper spans (order: left→right). */
+function forceRows(wrapperEls: Element[], rows: number[]) {
+  // rows like [3,3,2] => first 3 items row 0, next 3 row 1, etc.
+  let idx = 0;
+  rows.forEach((count, rowIdx) => {
+    for (let i = 0; i < count && idx < wrapperEls.length; i++, idx++) {
+      const top = rowIdx * 24; // arbitrary row step
+      Object.defineProperty(wrapperEls[idx], "offsetTop", {
+        configurable: true,
+        get() {
+          return top;
+        },
+      });
+    }
+  });
+  // Any remaining go to the last row
+  for (; idx < wrapperEls.length; idx++) {
+    const top = (rows.length - 1) * 24;
+    Object.defineProperty(wrapperEls[idx], "offsetTop", {
+      configurable: true,
+      get() {
+        return top;
+      },
+    });
+  }
+}
+
+/** Count only REAL badge wrappers (exclude the +n token wrapper). */
+function countBadgeWrappers(flex: HTMLElement): number {
+  return Array.from(flex.querySelectorAll("span.inline-block")).filter((el) =>
+    el.querySelector(":scope > span.inline-flex"),
+  ).length;
+}
+
+describe("auto-fit & maxRows", () => {
+  it("auto-fits to container width and shows '+n more' when rows exceed maxRows=1", async () => {
+    const items = ["A", "B", "C", "D", "E", "F"];
+    const { container } = render(<BadgeArray maxRows={1}>{items}</BadgeArray>);
+    // Root flex-wrap container
+    const flex = container.querySelector("div.flex.flex-wrap") as HTMLElement;
+    expect(flex).toBeTruthy();
+
+    // Narrow container (e.g., 160px). All wrappers share one row (offsetTop=0).
+    setContainerWidth(flex, 160);
+    const wrappers = Array.from(flex.querySelectorAll("span.inline-block"));
+    // Force 2 natural rows (exceeds maxRows=1) so trimming runs.
+    forceRows(wrappers, [4, 2]);
+
+    // Kick measurement
+    window.dispatchEvent(new Event("resize"));
+
+    await waitFor(() => {
+      const visibleWrappers = countBadgeWrappers(flex);
+      // "+n more" must appear when items overflow one row
+      const tokens = Array.from(flex.querySelectorAll("span")).filter(
+        (el) =>
+          /\+\d+ more/.test(el.textContent || "") &&
+          el.getAttribute("aria-hidden") !== "true" &&
+          !el.classList.contains("invisible"),
+      );
+      expect(tokens.length).toBeGreaterThan(0);
+      // We definitely didn't keep all 6
+      expect(visibleWrappers).toBeLessThan(items.length);
+    });
+
+    restoreContainerWidth(flex);
+  });
+
+  it("respects maxRows by collapsing excess rows with '+n more' on the last allowed row", async () => {
+    const items = ["A", "B", "C", "D", "E", "F", "G", "H"];
+    const { container } = render(<BadgeArray maxRows={2}>{items}</BadgeArray>);
+    const flex = container.querySelector("div.flex.flex-wrap") as HTMLElement;
+    setContainerWidth(flex, 240);
+    const wrappers = Array.from(flex.querySelectorAll("span.inline-block"));
+    // Force 3 natural rows (3,3,2). maxRows=2 should collapse part of row 2 with a token.
+    forceRows(wrappers, [3, 3, 2]);
+    window.dispatchEvent(new Event("resize"));
+
+    await waitFor(() => {
+      const token = Array.from(flex.querySelectorAll("span")).find(
+        (el) =>
+          /\+\d+ more/.test(el.textContent || "") &&
+          el.getAttribute("aria-hidden") !== "true" &&
+          !el.classList.contains("invisible"),
+      );
+      expect(token).toBeTruthy();
+      // Kept items should be <= 6 (two full rows) but > 0
+      const kept = flex.querySelectorAll("span.inline-block").length;
+      expect(kept).toBeGreaterThan(0);
+      expect(kept).toBeLessThan(items.length);
+    });
+    restoreContainerWidth(flex);
+  });
+
+  it("updates when resizing narrower (keeps fewer badges)", async () => {
+    const items = ["A", "B", "C", "D", "E", "F"];
+    const { container } = render(<BadgeArray maxRows={2}>{items}</BadgeArray>);
+    const flex = container.querySelector("div.flex.flex-wrap") as HTMLElement;
+    const wrappers = Array.from(flex.querySelectorAll("span.inline-block"));
+    // Start with a wide container, all on two rows (3,3)
+    setContainerWidth(flex, 400);
+    forceRows(wrappers, [3, 3]);
+    window.dispatchEvent(new Event("resize"));
+    await waitFor(() => {
+      const keptWide = countBadgeWrappers(flex);
+      expect(keptWide).toBe(items.length); // wide enough → keep all
+    });
+
+    // Now narrow it; still two natural rows (3,3) but token should force trimming
+    setContainerWidth(flex, 200);
+    // Force MORE rows than allowed so trimming occurs
+    forceRows(wrappers, [3, 2, 1]); // 3 rows > maxRows(2)
+    window.dispatchEvent(new Event("resize"));
+    await waitFor(() => {
+      const keptNarrow = countBadgeWrappers(flex);
+      expect(keptNarrow).toBeLessThan(items.length);
+      const token = Array.from(flex.querySelectorAll("span")).find(
+        (el) =>
+          /\+\d+ more/.test(el.textContent || "") &&
+          el.getAttribute("aria-hidden") !== "true" &&
+          !el.classList.contains("invisible"),
+      );
+      expect(token).toBeTruthy();
+    });
+    restoreContainerWidth(flex);
+  });
+
+  it("updates when resizing wider (keeps more badges again)", async () => {
+    const items = ["A", "B", "C", "D", "E", "F", "G"];
+    const { container } = render(<BadgeArray maxRows={1}>{items}</BadgeArray>);
+    const flex = container.querySelector("div.flex.flex-wrap") as HTMLElement;
+    const wrappers = Array.from(flex.querySelectorAll("span.inline-block"));
+    // Begin narrow → force trimming on one row
+    setContainerWidth(flex, 160);
+    forceRows(wrappers, [4, items.length - 4]); // rows=2 > allowed=1
+    // IMPORTANT: Force more natural rows than allowed (2 > 1) so trimming runs.
+    forceRows(wrappers, [4, 2]);
+    window.dispatchEvent(new Event("resize"));
+    await waitFor(() => {
+      const keptNarrow = countBadgeWrappers(flex);
+      expect(keptNarrow).toBeLessThan(items.length);
+    });
+    // Widen → our component should temporarily render all to measure, then keep more
+    setContainerWidth(flex, 600);
+    // With a wide container, rows collapse to 1 naturally
+    forceRows(wrappers, [items.length]);
+    window.dispatchEvent(new Event("resize"));
+    await waitFor(() => {
+      const keptWide = countBadgeWrappers(flex);
+      // With a wide container, all items fit on one row (maxRows=1) → keep all
+      expect(keptWide).toBe(items.length);
+      const token = Array.from(flex.querySelectorAll("span")).find(
+        (el) =>
+          /\+\d+ more/.test(el.textContent || "") &&
+          el.getAttribute("aria-hidden") !== "true" &&
+          !el.classList.contains("invisible"),
+      );
+      expect(token).toBeFalsy();
+    });
+    restoreContainerWidth(flex);
+  });
+
+  it("shows all items and no token when maxRows is Infinity", async () => {
+    const items = ["A", "B", "C", "D", "E"];
+    const { container } = render(
+      <BadgeArray maxRows={Infinity}>{items}</BadgeArray>,
+    );
+    const flex = container.querySelector("div.flex.flex-wrap") as HTMLElement;
+    setContainerWidth(flex, 120);
+    const wrappers = Array.from(flex.querySelectorAll("span.inline-block"));
+    forceRows(wrappers, [2, 2, 1]); // multiple rows naturally
+    window.dispatchEvent(new Event("resize"));
+    await waitFor(() => {
+      const kept = countBadgeWrappers(flex);
+      expect(kept).toBe(items.length); // infinite rows => show all
+      const token = Array.from(flex.querySelectorAll("span")).find(
+        (el) =>
+          /\+\d+ more/.test(el.textContent || "") &&
+          el.getAttribute("aria-hidden") !== "true" &&
+          !el.classList.contains("invisible"),
+      );
+      expect(token).toBeFalsy();
+    });
+    restoreContainerWidth(flex);
+  });
+
+  it("honors visibleCount override (legacy path) and ignores auto-fit", async () => {
+    const { container } = render(
+      <BadgeArray
+        visibleCount={2}
+        variant="sector"
+      >
+        {["A", "B", "C", "D"]}
+      </BadgeArray>,
+    );
+    // Exactly 2 wrappers rendered; token present
+    const flex = container.querySelector("div.flex.flex-wrap") as HTMLElement;
+    await waitFor(() => {
+      expect(countBadgeWrappers(flex)).toBe(2);
+    });
+    const token = Array.from(flex.querySelectorAll("span")).find(
+      (el) =>
+        /\+\d+ more/.test(el.textContent || "") &&
+        el.getAttribute("aria-hidden") !== "true" &&
+        !el.classList.contains("invisible"),
+    );
+    expect(token).toBeTruthy();
   });
 });

--- a/src/components/BadgeArray.test.tsx
+++ b/src/components/BadgeArray.test.tsx
@@ -11,34 +11,33 @@ describe("BadgeArray", () => {
   });
 
   it("applies a single variant to all badges", () => {
-    const { container } = render(
-      <BadgeArray variant="sector">{["Power", "Transport"]}</BadgeArray>,
-    );
-    const spans = container.querySelectorAll("span");
-    // Both badges should have the 'sector' styling
-    spans.forEach((el) => {
-      // each Badge renders a <span> with these classes
-      expect(el).toHaveClass("bg-solar-100");
-      expect(el).toHaveClass("text-solar-800");
-      expect(el).toHaveClass("border-solar-200");
-    });
+    render(<BadgeArray variant="sector">{["Power", "Transport"]}</BadgeArray>);
+    const power = screen.getByText("Power").closest("span") as HTMLElement;
+    const transport = screen
+      .getByText("Transport")
+      .closest("span") as HTMLElement;
+    expect(power).toHaveClass("bg-solar-100");
+    expect(power).toHaveClass("text-solar-800");
+    expect(power).toHaveClass("border-solar-200");
+    expect(transport).toHaveClass("bg-solar-100");
+    expect(transport).toHaveClass("text-solar-800");
+    expect(transport).toHaveClass("border-solar-200");
   });
 
   it("applies per-item variants when variant is an array", () => {
-    const { container } = render(
+    render(
       <BadgeArray variant={["sector", "year"]}>{["Power", "2050"]}</BadgeArray>,
     );
-    const [first, second] = Array.from(container.querySelectorAll("span"));
-
+    const sectorSpan = screen.getByText("Power").closest("span") as HTMLElement;
+    const yearSpan = screen.getByText("2050").closest("span") as HTMLElement;
     // sector
-    expect(first).toHaveClass("bg-solar-100");
-    expect(first).toHaveClass("text-solar-800");
-    expect(first).toHaveClass("border-solar-200");
-
+    expect(sectorSpan).toHaveClass("bg-solar-100");
+    expect(sectorSpan).toHaveClass("text-solar-800");
+    expect(sectorSpan).toHaveClass("border-solar-200");
     // year
-    expect(second).toHaveClass("bg-rmiblue-100");
-    expect(second).toHaveClass("text-rmiblue-800");
-    expect(second).toHaveClass("border-rmiblue-200");
+    expect(yearSpan).toHaveClass("bg-rmiblue-100");
+    expect(yearSpan).toHaveClass("text-rmiblue-800");
+    expect(yearSpan).toHaveClass("border-rmiblue-200");
   });
 
   it("supports toLabel for present values", () => {

--- a/src/components/BadgeArray.tsx
+++ b/src/components/BadgeArray.tsx
@@ -124,7 +124,6 @@ export default function BadgeArray<T extends Scalar = Scalar>({
     // Are we measuring the full list (all items rendered) or a trimmed subset?
     const measuringFull = wrappers.length === arr.length;
 
-
     // Let the browser lay everything out; then read rows.
     const rows = groupIntoRows(wrappers);
     const allowed = Math.max(1, Math.floor(maxRows));
@@ -211,13 +210,16 @@ export default function BadgeArray<T extends Scalar = Scalar>({
     typeof visibleCount === "number"
       ? visibleCount
       : renderAllOnce
-      ? arr.length // temporarily render all to measure expansion capacity
-      : autoVisible ?? arr.length;
+        ? arr.length // temporarily render all to measure expansion capacity
+        : (autoVisible ?? arr.length);
   const showMore =
     finalVisible < arr.length && Number.isFinite(maxRows) && finalVisible >= 0;
 
   return (
-    <div ref={containerRef} className="flex flex-wrap">
+    <div
+      ref={containerRef}
+      className="flex flex-wrap"
+    >
       {/* Hidden, dynamic measurer for the "+N more" token */}
       <span
         ref={moreMeasureRef}

--- a/src/components/BadgeArray.tsx
+++ b/src/components/BadgeArray.tsx
@@ -227,7 +227,6 @@ export default function BadgeArray<T extends Scalar = Scalar>({
         ref={moreMeasureRef}
         aria-hidden="true"
         className="invisible absolute whitespace-nowrap text-xs"
-        style={{ position: "absolute" }}
       >
         +0 more
       </span>

--- a/src/components/ScenarioCard.test.tsx
+++ b/src/components/ScenarioCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import ScenarioCard from "./ScenarioCard";
 import { Scenario } from "../types";
@@ -153,32 +153,74 @@ describe("ScenarioCard component", () => {
   });
 
   describe("'+n more' tooltip functionality", () => {
-    it("shows '+n more' text when there are too many sectors to display", () => {
-      const { container } = renderScenarioCard(mockScenarioFull);
-
-      // Find the sectors section
-      const sectorsSection = Array.from(container.querySelectorAll("p")).find(
-        (p) => p.textContent === "Sectors:",
+    it("shows '+n more' text when there are too many sectors to display", async () => {
+      const { container } = withClientWidth(220, () =>
+        renderScenarioCard(mockScenarioFull),
       );
 
-      if (!sectorsSection) {
-        throw new Error("Sectors section not found");
-      }
+      // Find the "Sectors:" label
+      const sectorsP = Array.from(container.querySelectorAll("p")).find(
+        (p) => p.textContent === "Sectors:",
+      );
+      if (!sectorsP) throw new Error("Sectors section not found");
 
-      // Get the parent div of the Sectors section
-      const sectorsSectionContainer = sectorsSection.closest("div");
+      // The flex-wrap container is the sibling <div> following the <p>Sectors:</p>
+      const sectorsFlex =
+        (sectorsP.parentElement &&
+          sectorsP.parentElement.querySelector("div.flex.flex-wrap")) ||
+        null;
+      if (!sectorsFlex) throw new Error("Sectors flex container not found");
 
-      // Check if any "+n more" text exists within the sectors section
-      const moreTextElements = Array.from(
-        sectorsSectionContainer?.querySelectorAll("span") || [],
-      ).filter((span) => /\+\d+ more/.test(span.textContent || ""));
+      // Stub container rect so BadgeArray has a concrete width to compare against
+      const origGetRect = () => sectorsFlex.getBoundingClientRect();
+      sectorsFlex.getBoundingClientRect = () =>
+        ({ left: 0, right: 220, width: 220, top: 0, bottom: 0 }) as DOMRect;
 
-      // There should be at least one "+n more" element
-      expect(moreTextElements.length).toBeGreaterThan(0);
+      // Badge wrappers are the immediate children spans with inline-block
+      const wrappers = Array.from(
+        sectorsFlex.querySelectorAll("span.inline-block"),
+      );
+      // Force 3 rows via offsetTop: 0, 24, 48...
+      wrappers.forEach((el, i) => {
+        const top = i < 3 ? 0 : i < 6 ? 24 : 48;
+        Object.defineProperty(el, "offsetTop", {
+          configurable: true,
+          get() {
+            return top;
+          },
+        });
+      });
+
+      // Trigger recomputation (ResizeObserver/resize listener)
+      window.dispatchEvent(new Event("resize"));
+
+      // Wait for the measurement cycle to complete and the visible token to appear
+      await waitFor(() => {
+        const visibleTokens = Array.from(
+          sectorsFlex.querySelectorAll("span"),
+        ).filter(
+          (el) =>
+            /\+\d+ more/.test(el.textContent || "") &&
+            el.getAttribute("aria-hidden") !== "true" &&
+            !el.classList.contains("invisible"),
+        );
+        expect(visibleTokens.length).toBeGreaterThan(0);
+      });
+
+      // Restore original getBoundingClientRect (avoid side effects)
+      sectorsFlex.getBoundingClientRect = origGetRect;
 
       // The number in "+n more" should be positive
+      const visibleMoreText = Array.from(
+        sectorsFlex.querySelectorAll("span"),
+      ).filter(
+        (el) =>
+          /\+\d+ more/.test(el.textContent || "") &&
+          el.getAttribute("aria-hidden") !== "true" &&
+          !el.classList.contains("invisible"),
+      );
       const moreTextMatch =
-        moreTextElements[0].textContent?.match(/\+(\d+) more/);
+        visibleMoreText[0].textContent?.match(/\+(\d+) more/);
       expect(moreTextMatch).not.toBeNull();
       if (moreTextMatch) {
         const countNumber = parseInt(moreTextMatch[1]);

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -172,9 +172,7 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
           <p className="text-xs font-medium text-rmigray-500 mb-1">
             Geographies:
           </p>
-          <div
-            className="flex flex-wrap"
-          >
+          <div className="flex flex-wrap">
             <BadgeArray
               variant={sortedGeography.map(
                 (geo) => geographyVariant(geographyKind(geo)) as string,
@@ -191,9 +189,7 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
         {/* Sectors section with dynamic badge count */}
         <div className="mb-3">
           <p className="text-xs font-medium text-rmigray-500 mb-1">Sectors:</p>
-          <div
-            className="flex flex-wrap"
-          >
+          <div className="flex flex-wrap">
             <BadgeArray
               variant="sector"
               tooltipGetter={getSectorTooltip}
@@ -210,9 +206,7 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
           <p className="text-xs font-medium text-rmigray-500 mb-1">
             Benchmark Metrics:
           </p>
-          <div
-            className="flex flex-wrap"
-          >
+          <div className="flex flex-wrap">
             <BadgeArray
               variant="metric"
               tooltipGetter={getMetricTooltip}

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -88,29 +88,6 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
     [scenario.sectors, searchTerm],
   );
 
-  // Refs for the container elements
-  const geographyContainerRef = useRef<HTMLDivElement>(null);
-  const sectorsContainerRef = useRef<HTMLDivElement>(null);
-  const metricContainerRef = useRef<HTMLDivElement>(null);
-
-  // Calculate how many badges can fit in each container
-  const geographyBadgeWidth = 90; // Estimated average width of a geography badge in pixels
-  const sectorBadgeWidth = 80; // Estimated average width of a sector badge in pixels
-  const metricBadgeWidth = 80; // Estimated average width of a metric badge in pixels
-
-  const visibleGeographyCount = useAvailableBadgeCount(
-    geographyContainerRef,
-    geographyBadgeWidth,
-  );
-  const visibleSectorsCount = useAvailableBadgeCount(
-    sectorsContainerRef,
-    sectorBadgeWidth,
-  );
-  const visibleMetricCount = useAvailableBadgeCount(
-    metricContainerRef,
-    metricBadgeWidth,
-  );
-
   // Helper function to conditionally highlight text based on search term
   const highlightTextIfSearchMatch = (
     value: string | number | undefined | null | boolean,
@@ -196,7 +173,6 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
             Geographies:
           </p>
           <div
-            ref={geographyContainerRef}
             className="flex flex-wrap"
           >
             <BadgeArray
@@ -204,8 +180,8 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
                 (geo) => geographyVariant(geographyKind(geo)) as string,
               )}
               toLabel={(geo) => geographyLabel(normalizeGeography(geo))}
-              visibleCount={visibleGeographyCount}
               renderLabel={(label) => highlightTextIfSearchMatch(label)}
+              maxRows={1}
             >
               {sortedGeography}
             </BadgeArray>
@@ -216,14 +192,13 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
         <div className="mb-3">
           <p className="text-xs font-medium text-rmigray-500 mb-1">Sectors:</p>
           <div
-            ref={sectorsContainerRef}
             className="flex flex-wrap"
           >
             <BadgeArray
-              visibleCount={visibleSectorsCount}
               variant="sector"
               tooltipGetter={getSectorTooltip}
               renderLabel={(label) => highlightTextIfSearchMatch(label)}
+              maxRows={1}
             >
               {sortedSectors.map((sector) => sector.name)}
             </BadgeArray>
@@ -236,14 +211,13 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
             Benchmark Metrics:
           </p>
           <div
-            ref={metricContainerRef}
             className="flex flex-wrap"
           >
             <BadgeArray
-              visibleCount={visibleMetricCount}
               variant="metric"
               tooltipGetter={getMetricTooltip}
               renderLabel={(label) => highlightTextIfSearchMatch(label)}
+              maxRows={1}
             >
               {scenario.metric}
             </BadgeArray>

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -181,7 +181,7 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
               )}
               toLabel={(geo) => geographyLabel(normalizeGeography(geo))}
               renderLabel={(label) => highlightTextIfSearchMatch(label)}
-              maxRows={1}
+              maxRows={2}
             >
               {sortedGeography}
             </BadgeArray>
@@ -198,7 +198,7 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
               variant="sector"
               tooltipGetter={getSectorTooltip}
               renderLabel={(label) => highlightTextIfSearchMatch(label)}
-              maxRows={1}
+              maxRows={2}
             >
               {sortedSectors.map((sector) => sector.name)}
             </BadgeArray>
@@ -217,7 +217,7 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
               variant="metric"
               tooltipGetter={getMetricTooltip}
               renderLabel={(label) => highlightTextIfSearchMatch(label)}
-              maxRows={1}
+              maxRows={2}
             >
               {scenario.metric}
             </BadgeArray>

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState, useEffect, RefObject } from "react";
+import React, { useMemo } from "react";
 import { Link } from "react-router-dom";
 import { BadgeMaybeAbsent } from "./Badge";
 import BadgeArray from "./BadgeArray";
@@ -24,50 +24,7 @@ interface ScenarioCardProps {
   searchTerm?: string;
 }
 
-type MaybeHTMLElement = HTMLElement | null;
-
 // Custom hook to measure container width and calculate how many badges will fit
-const useAvailableBadgeCount = (
-  containerRef: RefObject<MaybeHTMLElement>,
-  itemWidth = 100,
-  gap = 8,
-) => {
-  const [availableBadgeCount, setAvailableBadgeCount] = useState(3); // Default to 3 as minimum
-
-  useEffect(() => {
-    if (!containerRef.current) return;
-
-    const updateBadgeCount = () => {
-      const containerWidth = containerRef.current?.clientWidth || 0;
-      const possibleBadges = Math.floor(
-        (containerWidth + gap) / (itemWidth + gap),
-      );
-
-      // Ensure we show at least 1 badge, and cap at a reasonable maximum (e.g., 8)
-      const badgeCount = Math.max(1, Math.min(possibleBadges, 8));
-      setAvailableBadgeCount(badgeCount);
-    };
-
-    // Calculate on mount
-    updateBadgeCount();
-
-    // Recalculate when window resizes
-    const resizeObserver = new ResizeObserver(updateBadgeCount);
-    const observedElement = containerRef.current;
-    if (observedElement) {
-      resizeObserver.observe(observedElement);
-    }
-
-    return () => {
-      if (observedElement) {
-        resizeObserver.unobserve(observedElement);
-      }
-      resizeObserver.disconnect();
-    };
-  }, [containerRef, itemWidth, gap]);
-
-  return availableBadgeCount;
-};
 
 const ScenarioCard: React.FC<ScenarioCardProps> = ({
   scenario,


### PR DESCRIPTION
Adds behavior to BadgeArray to fit badges into the provided space, including reflow (adjust number of badges) on space resizing. Gives the option to use multiple rows, if desired, and if an explicit `visibleCount` (current behavior) is provided, uses that instead. 

Closes #214 
supports #358 