### PR TITLE
Multiselect dropdown UI (PBTAR-56)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
+        "clsx": "^2.1.1",
         "i18n-iso-countries": "^7.14.0",
         "lucide-react": "^0.544.0",
         "react": "^19.1.1",
@@ -4375,6 +4376,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
+    "clsx": "^2.1.1",
     "i18n-iso-countries": "^7.14.0",
     "lucide-react": "^0.544.0",
     "react": "^19.1.1",

--- a/src/components/MultiSelectDropdown.test.tsx
+++ b/src/components/MultiSelectDropdown.test.tsx
@@ -140,7 +140,8 @@ function openMenu() {
 }
 
 describe("MultiSelectDropdown – variable widths", () => {
-  const getBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+  const getBoundingClientRect =
+    HTMLElement.prototype.getBoundingClientRect.bind(HTMLElement.prototype);
 
   beforeEach(() => {
     // Default: mock a 160px-wide trigger button
@@ -162,7 +163,7 @@ describe("MultiSelectDropdown – variable widths", () => {
           x: 0,
           y: 0,
           toJSON: () => {},
-        } as any;
+        };
       }
       return {
         width: 0,
@@ -174,8 +175,8 @@ describe("MultiSelectDropdown – variable widths", () => {
         x: 0,
         y: 0,
         toJSON: () => {},
-      } as any;
-    }) as any;
+      };
+    });
   });
 
   afterEach(() => {

--- a/src/components/MultiSelectDropdown.test.tsx
+++ b/src/components/MultiSelectDropdown.test.tsx
@@ -259,3 +259,90 @@ describe("MultiSelectDropdown – variable widths", () => {
     expect(btn.className).toMatch(/\bmin-w-40\b/);
   });
 });
+
+describe("MultiSelectDropdown – active visual state", () => {
+  // Bind original so we can restore safely (avoids unbound-method + invalid `this`)
+  const originalGetBCR = HTMLElement.prototype.getBoundingClientRect.bind(
+    HTMLElement.prototype,
+  );
+
+  beforeEach(() => {
+    HTMLElement.prototype.getBoundingClientRect = vi.fn(function (
+      this: HTMLElement,
+    ) {
+      if (
+        this.getAttribute("role") === "button" ||
+        this.tagName.toLowerCase() === "button"
+      ) {
+        return {
+          width: 160,
+          height: 32,
+          top: 0,
+          left: 0,
+          bottom: 0,
+          right: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => {},
+        };
+      }
+      return {
+        width: 0,
+        height: 0,
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      };
+    });
+  });
+
+  afterEach(() => {
+    HTMLElement.prototype.getBoundingClientRect = originalGetBCR;
+  });
+
+  it("renders neutral trigger styles when there are no selections", () => {
+    render(
+      <MultiSelectDropdown
+        label="Geography"
+        options={[
+          { value: "na", label: "North America" },
+          { value: "eu", label: "Europe" },
+        ]}
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    const btn = screen.getByRole("button");
+    // Neutral classes present
+    expect(btn.className).toMatch(/\bbg-white\b/);
+    expect(btn.className).toMatch(/\bborder-gray-300\b/);
+    // Active classes absent
+    expect(btn.className).not.toMatch(/\bbg-energy-100\b/);
+    expect(btn.className).not.toMatch(/\bborder-energy-100\b/);
+  });
+
+  it("renders active trigger styles when there is at least one selection", () => {
+    render(
+      <MultiSelectDropdown
+        label="Geography"
+        options={[
+          { value: "na", label: "North America" },
+          { value: "eu", label: "Europe" },
+        ]}
+        value={["eu"]}
+        onChange={() => {}}
+      />,
+    );
+    const btn = screen.getByRole("button");
+    // Active classes present
+    expect(btn.className).toMatch(/\bbg-energy-100\b/);
+    expect(btn.className).toMatch(/\bborder-energy-100\b/);
+    expect(btn.className).toMatch(/\btext-energy-800\b/);
+    // Neutral background absent
+    expect(btn.className).not.toMatch(/\bbg-white\b/);
+  });
+});

--- a/src/components/MultiSelectDropdown.test.tsx
+++ b/src/components/MultiSelectDropdown.test.tsx
@@ -42,7 +42,7 @@ describe("<MultiSelectDropdown>", () => {
     );
 
     // open
-    await user.click(screen.getByText("Select…"));
+    await user.click(screen.getByRole("button", { name: /select/i }));
 
     // toggle EU → ["EU"]
     await user.click(screen.getByLabelText("Europe"));
@@ -71,7 +71,7 @@ describe("<MultiSelectDropdown>", () => {
       />,
     );
 
-    await user.click(screen.getByText("Select…"));
+    await user.click(screen.getByRole("button", { name: /select/i }));
     await user.click(screen.getByTitle("Match all (AND)"));
     expect(onModeChange).toHaveBeenLastCalledWith("ALL");
   });
@@ -93,7 +93,7 @@ describe("<MultiSelectDropdown>", () => {
     );
 
     // open
-    await user.click(screen.getByText("Select…"));
+    await user.click(screen.getByRole("button", { name: /years/i }));
 
     // toggle 2025
     await user.click(screen.getByLabelText("2025"));
@@ -119,11 +119,11 @@ it("closes on outside click but not when re-clicking the trigger", async () => {
   );
 
   // open
-  await user.click(screen.getByText("Select…"));
+  await user.click(screen.getByRole("button", { name: /select/i }));
   expect(screen.getByRole("listbox")).toBeInTheDocument();
 
   // Click trigger again → still open (does not close)
-  await user.click(screen.getByText("Select…"));
+  await user.click(getTrigger());
   expect(screen.getByRole("listbox")).toBeInTheDocument();
 
   // Click outside → closed
@@ -136,8 +136,18 @@ const OPTIONS: Option<string>[] = [
   { value: "b", label: "Beta" },
 ];
 
+// Helper to uniquely select the trigger (not "Select all", not the clear X)
+function getTrigger(): HTMLButtonElement {
+  const el = screen
+    .getAllByRole("button")
+    .find((n) => n.getAttribute("aria-haspopup") === "listbox");
+  if (!el)
+    throw new Error("Trigger button with aria-haspopup='listbox' not found");
+  return el as HTMLButtonElement;
+}
+
 function openMenu() {
-  fireEvent.click(screen.getByRole("button"));
+  fireEvent.click(getTrigger());
 }
 
 describe("MultiSelectDropdown – variable widths", () => {
@@ -339,7 +349,7 @@ describe("MultiSelectDropdown – active visual state", () => {
       />,
     );
     // The trigger's accessible name is the visible text inside it, e.g. "1 selected"
-    const btn = screen.getByRole("button", { name: /selected/i });
+    const btn = getTrigger();
     // Active classes present
     expect(btn.className).toMatch(/\bbg-energy-100\b/);
     expect(btn.className).toMatch(/\bborder-energy-100\b/);
@@ -414,7 +424,7 @@ describe("MultiSelectDropdown – trigger affordance (ChevronDown vs X)", () => 
     ).toBeNull();
 
     // Click trigger -> menu should open (listbox appears)
-    await user.click(screen.getByRole("button", { name: /select/i }));
+    await user.click(screen.getByRole("button", { name: /Geography/i }));
     expect(await screen.findByRole("listbox")).toBeInTheDocument();
   });
 
@@ -444,7 +454,7 @@ describe("MultiSelectDropdown – trigger affordance (ChevronDown vs X)", () => 
     expect(screen.queryByRole("listbox")).toBeNull();
 
     // Simulate user adding a 3rd sector: clicking the trigger (still active) should open the menu
-    await user.click(screen.getByRole("button", { name: /selected/i })); // e.g., "1 selected"
+    await user.click(getTrigger());
     expect(await screen.findByRole("listbox")).toBeInTheDocument();
   });
 });
@@ -609,7 +619,7 @@ describe("MultiSelectDropdown – menu header layout & interactions", () => {
       );
     }
     render(<Harness />);
-    await user.click(screen.getByRole("button", { name: /select/i }));
+    await user.click(screen.getByRole("button", { name: /geography/i }));
     const btnAny = screen.getByRole("button", { name: /^Any$/i });
     const btnAll = screen.getByRole("button", { name: /^All$/i });
     // starts at ANY

--- a/src/components/MultiSelectDropdown.tsx
+++ b/src/components/MultiSelectDropdown.tsx
@@ -34,7 +34,7 @@ export default function MultiSelectDropdown<
   options,
   value,
   onChange,
-  placeholder = "Select…",
+  placeholder = "Select",
   className,
   triggerMinWidthClassName = "min-w-32",
   menuWidthClassName,
@@ -128,10 +128,6 @@ export default function MultiSelectDropdown<
 
   return (
     <div className={className}>
-      {label ? (
-        <div className="mb-1 text-sm font-medium text-rmigray-700">{label}</div>
-      ) : null}
-
       <button
         ref={triggerRef}
         type="button"
@@ -146,33 +142,50 @@ export default function MultiSelectDropdown<
         aria-haspopup="listbox"
         aria-expanded={open}
       >
-        <span className="truncate">
-          {current.length === 0 ? placeholder : `${current.length} selected`}
+        <span className="truncate inline-flex items-baseline">
+          <span className="relative inline-block [font-variant-numeric:tabular-nums]">
+            {/* Reserve space for label + ': 99' */}
+            <span
+              aria-hidden
+              className="opacity-0 select-none whitespace-pre"
+            >
+              {label ?? placeholder}: 99
+            </span>
+
+            {/* Actual content, overlayed */}
+            <span className="absolute inset-0 whitespace-pre">
+              {current.length === 0
+                ? `${label ?? placeholder}...`
+                : `${label ?? placeholder}: `}
+              {current.length > 0 && <strong>{current.length}</strong>}
+            </span>
+          </span>
         </span>
 
-        {isActive ? (
-          <span
-            role="button"
-            aria-label={`Clear ${label ?? "filter"}`}
-            className="ml-2 inline-flex h-5 w-5 items-center justify-center rounded cursor-pointer hover:bg-energy-200 focus:outline-none"
-            onClick={(e) => {
-              e.stopPropagation(); // don't open the menu
-              onChange([]);
-            }}
-            onMouseDown={(e) => e.preventDefault()} // prevent focusing/activating parent button
-          >
-            <X
+        <span className="ml-2 inline-flex h-5 w-5 items-center justify-center flex-shrink-0">
+          {isActive ? (
+            <span
+              role="button"
+              aria-label={`Clear ${label ?? "filter"}`}
+              className="inline-flex h-5 w-5 items-center justify-center rounded cursor-pointer hover:bg-energy-200 focus:outline-none"
+              onClick={(e) => {
+                e.stopPropagation(); // don't open the menu
+                onChange([]);
+              }}
+              onMouseDown={(e) => e.preventDefault()} // prevent focusing/activating parent button
+            >
+              <X
+                size={16}
+                aria-hidden
+              />
+            </span>
+          ) : (
+            <ChevronDown
               size={16}
               aria-hidden
             />
-          </span>
-        ) : (
-          <ChevronDown
-            size={16}
-            className="ml-2"
-            aria-hidden
-          />
-        )}
+          )}
+        </span>
       </button>
 
       {open && (

--- a/src/components/MultiSelectDropdown.tsx
+++ b/src/components/MultiSelectDropdown.tsx
@@ -67,11 +67,18 @@ export default function MultiSelectDropdown<
   }, []);
 
   // Coerce scalar/null/undefined → T[]
+  // Normalize current values to an array for easy checks
   const current = React.useMemo<T[]>(
     () =>
-      Array.isArray(value) ? value : value != null ? ([value] as T[]) : [],
+      Array.isArray(value)
+        ? value.filter((v): v is T => v !== null && v !== undefined)
+        : value === null || value === undefined
+          ? []
+          : [value],
     [value],
   );
+
+  const isActive = current.length > 0;
 
   // We compare using string forms to support number values safely
   const toKey = React.useCallback((v: T) => String(v), []);
@@ -128,8 +135,11 @@ export default function MultiSelectDropdown<
         ref={triggerRef}
         type="button"
         className={clsx(
-          // size to content; keep a sensible floor with min-width
-          "inline-flex w-auto items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-left text-sm shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500",
+          "inline-flex w-auto items-center justify-between rounded-md px-3 py-2 text-left text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500",
+          // Active vs. neutral visual state (mirrors FilterDropdown)
+          isActive
+            ? "text-energy-800 bg-energy-100 border border-energy-100"
+            : "text-rmigray-800 bg-white border border-gray-300 hover:bg-gray-50",
           triggerMinWidthClassName,
         )}
         onClick={() => setOpen(true)} // only opens; closing is via outside click/Escape

--- a/src/components/MultiSelectDropdown.tsx
+++ b/src/components/MultiSelectDropdown.tsx
@@ -182,6 +182,7 @@ export default function MultiSelectDropdown<
         >
           <div
             className={clsx(
+              // enforce a sensible base width so the header can show L/R columns
               "absolute z-20 mt-2 origin-top-right rounded-md border border-gray-200 bg-white shadow-lg focus:outline-none",
               // If a fixed width is provided, use it; else rely on minWidth style below
               menuWidthClassName ?? null,
@@ -196,11 +197,12 @@ export default function MultiSelectDropdown<
                   }
             }
           >
-            <div className="flex items-center justify-between px-2 pb-2 text-xs">
-              <div className="flex items-center gap-2">
+            <div className="flex items-start justify-between px-2 pb-2 text-xs gap-2">
+              {/* Left column: actions. Allow wrapping, but keep "Select all" on one line */}
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
                 <button
                   type="button"
-                  className="underline disabled:opacity-50"
+                  className="underline disabled:opacity-50 whitespace-nowrap"
                   onClick={selectAll}
                   disabled={allSelected || enabled.length === 0}
                 >
@@ -216,30 +218,46 @@ export default function MultiSelectDropdown<
                 </button>
               </div>
 
+              {/* Right column: bordered, right-justified explainer */}
               {showModeToggle && onModeChange ? (
-                <div
-                  className="flex items-center gap-1"
-                  role="group"
-                  aria-label="Match mode"
-                >
-                  <button
-                    type="button"
-                    className={`px-2 py-1 rounded ${mode === "ANY" ? "bg-gray-100" : ""}`}
-                    onClick={() => onModeChange("ANY")}
-                    aria-pressed={mode === "ANY"}
-                    title="Match any (OR)"
+                <div className="text-right text-rmigray-500 px-0 py-0 inline-block">
+                  <div className="whitespace-nowrap">
+                    Show scenarios matching
+                  </div>
+                  <div
+                    className="mt-1 flex items-center justify-end gap-1"
+                    role="group"
+                    aria-label="Match mode"
+                    data-testid="mode-explainer"
                   >
-                    Any
-                  </button>
-                  <button
-                    type="button"
-                    className={`px-2 py-1 rounded ${mode === "ALL" ? "bg-gray-100" : ""}`}
-                    onClick={() => onModeChange("ALL")}
-                    aria-pressed={mode === "ALL"}
-                    title="Match all (AND)"
-                  >
-                    All
-                  </button>
+                    <div className="border border-gray-200 rounded-md">
+                      <button
+                        type="button"
+                        className={clsx(
+                          "px-[2px] py-[2px] rounded",
+                          mode === "ANY" && "bg-gray-100",
+                        )}
+                        onClick={() => onModeChange("ANY")}
+                        aria-pressed={mode === "ANY"}
+                        title="Match any (OR)"
+                      >
+                        Any
+                      </button>
+                      <button
+                        type="button"
+                        className={clsx(
+                          "px-[2px] py-[2px] rounded",
+                          mode === "ALL" && "bg-gray-100",
+                        )}
+                        onClick={() => onModeChange("ALL")}
+                        aria-pressed={mode === "ALL"}
+                        title="Match all (AND)"
+                      >
+                        All
+                      </button>
+                    </div>
+                    <span>selected</span>
+                  </div>
                 </div>
               ) : null}
             </div>

--- a/src/components/MultiSelectDropdown.tsx
+++ b/src/components/MultiSelectDropdown.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { FacetMode } from "../utils/searchUtils";
 import clsx from "clsx";
+import { ChevronDown, X } from "lucide-react";
 
 export type Option<T extends string | number = string> = {
   value: T;
@@ -136,25 +137,42 @@ export default function MultiSelectDropdown<
         type="button"
         className={clsx(
           "inline-flex w-auto items-center justify-between rounded-md px-3 py-2 text-left text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500",
-          // Active vs. neutral visual state (mirrors FilterDropdown)
           isActive
             ? "text-energy-800 bg-energy-100 border border-energy-100"
             : "text-rmigray-800 bg-white border border-gray-300 hover:bg-gray-50",
           triggerMinWidthClassName,
         )}
-        onClick={() => setOpen(true)} // only opens; closing is via outside click/Escape
+        onClick={() => setOpen(true)} // ← always opens, regardless of isActive
         aria-haspopup="listbox"
         aria-expanded={open}
       >
         <span className="truncate">
           {current.length === 0 ? placeholder : `${current.length} selected`}
         </span>
-        <span
-          aria-hidden
-          className="ml-2"
-        >
-          ▾
-        </span>
+
+        {isActive ? (
+          <span
+            role="button"
+            aria-label={`Clear ${label ?? "filter"}`}
+            className="ml-2 inline-flex h-5 w-5 items-center justify-center rounded cursor-pointer hover:bg-energy-200 focus:outline-none"
+            onClick={(e) => {
+              e.stopPropagation(); // don't open the menu
+              onChange([]);
+            }}
+            onMouseDown={(e) => e.preventDefault()} // prevent focusing/activating parent button
+          >
+            <X
+              size={16}
+              aria-hidden
+            />
+          </span>
+        ) : (
+          <ChevronDown
+            size={16}
+            className="ml-2"
+            aria-hidden
+          />
+        )}
       </button>
 
       {open && (

--- a/src/components/SearchSection.test.tsx
+++ b/src/components/SearchSection.test.tsx
@@ -167,4 +167,32 @@ describe("SearchSection", () => {
       });
     }
   });
+
+  describe("Clear all filters button (inline with summary)", () => {
+    it("does not render the button when no filters are applied", () => {
+      render(<SearchSection {...defaultProps} />);
+      expect(screen.queryByTestId("clear-all-filters")).toBeNull();
+      // Summary still renders
+      expect(screen.getByText(/Found 2 scenarios/i)).toBeInTheDocument();
+    });
+
+    it("renders the inline button when any filter is applied and calls onClear", () => {
+      const props = {
+        ...defaultProps,
+        filters: { ...defaultProps.filters, geography: ["Europe"] },
+      };
+      render(<SearchSection {...props} />);
+
+      // Button should be present and visually near the summary (inline within the same <p>)
+      const paragraph = screen.getByText(/Found \d+ scenarios/i).closest("p");
+      expect(paragraph).toBeTruthy();
+      const clearBtn = screen.getByTestId("clear-all-filters");
+      expect(clearBtn).toBeInTheDocument();
+      // Ensure the button is inside the same paragraph node (inline placement)
+      expect(paragraph?.contains(clearBtn)).toBe(true);
+
+      clearBtn.click();
+      expect(defaultProps.onClear).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/components/SearchSection.test.tsx
+++ b/src/components/SearchSection.test.tsx
@@ -28,12 +28,10 @@ describe("SearchSection", () => {
   });
 
   function openByLabel(labelText: string) {
-    const labelEl = screen.getByText(labelText);
-    const wrapper = labelEl.parentElement;
-    if (!wrapper) throw new Error("Wrapper not found for label: " + labelText);
-    const btn = wrapper.querySelector("button");
-    if (!btn)
-      throw new Error("Dropdown trigger button not found for: " + labelText);
+    // Labels now live inside the trigger’s accessible name (e.g., "Sector..." or "Sector: 3").
+    const btn = screen.getByRole("button", {
+      name: new RegExp(`^${labelText}\\b`, "i"),
+    });
     fireEvent.click(btn);
     return btn;
   }
@@ -41,11 +39,22 @@ describe("SearchSection", () => {
   it("renders all filter dropdowns", () => {
     render(<SearchSection {...defaultProps} />);
 
-    expect(screen.getByText("Pathway Type")).toBeInTheDocument();
-    expect(screen.getByText("Target Year")).toBeInTheDocument();
-    expect(screen.getByText("Temperature (°C)")).toBeInTheDocument();
-    expect(screen.getByText("Geography")).toBeInTheDocument();
-    expect(screen.getByText("Sector")).toBeInTheDocument();
+    // Labels are the button’s accessible name prefix (followed by "..." or ": N").
+    expect(
+      screen.getByRole("button", { name: /^Pathway Type\b/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^Target Year\b/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^Temperature\b/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^Geography\b/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^Sector\b/i }),
+    ).toBeInTheDocument();
   });
 
   // This test checks that sectors are properly extracted from the complex object structure
@@ -84,10 +93,9 @@ describe("SearchSection", () => {
       filters: { sector: ["Power"] } as unknown as SearchFilters,
     };
     render(<SearchSection {...propsWithSector} />);
-    // Trigger shows "1 selected"
-    const labelEl = screen.getByText("Sector");
-    const wrapper = labelEl.parentElement as HTMLElement;
-    expect(wrapper.querySelector("button")?.textContent).toMatch(/1 selected/i);
+    // Trigger shows "Sector: 1"
+    const trigger = screen.getByRole("button", { name: /^Sector\b/i });
+    expect(trigger).toHaveTextContent(/Sector:\s*1/i);
   });
 
   it("can clear selected sector filter", () => {
@@ -120,9 +128,7 @@ describe("SearchSection", () => {
 
   it("Geography: mode toggle to ALL dispatches modes update", () => {
     render(<SearchSection {...defaultProps} />);
-    const label = screen.getByText("Geography");
-    const wrapper = label.parentElement as HTMLElement;
-    const trigger = wrapper.querySelector('button[aria-haspopup="listbox"]')!;
+    const trigger = screen.getByRole("button", { name: /^Geography\b/i });
     fireEvent.click(trigger);
     fireEvent.click(screen.getByTitle("Match all (AND)"));
     expect(defaultProps.onFilterChange).toHaveBeenCalledWith("modes", {
@@ -136,9 +142,7 @@ describe("SearchSection", () => {
       filters: { modes: { sector: "ALL" } } as unknown as SearchFilters,
     };
     render(<SearchSection {...props} />);
-    const label = screen.getByText("Sector");
-    const wrapper = label.parentElement as HTMLElement;
-    const trigger = wrapper.querySelector('button[aria-haspopup="listbox"]')!;
+    const trigger = screen.getByRole("button", { name: /^Sector\b/i });
     fireEvent.click(trigger);
     fireEvent.click(screen.getByTitle("Match any (OR)"));
     expect(defaultProps.onFilterChange).toHaveBeenCalledWith("modes", {
@@ -150,15 +154,13 @@ describe("SearchSection", () => {
     for (const facet of [
       "Pathway Type",
       "Target Year",
-      "Temperature (°C)",
+      "Temperature",
     ] as const) {
       it(`facet: ${facet}`, () => {
         render(<SearchSection {...defaultProps} />);
-        const label = screen.getByText(facet);
-        const wrapper = label.parentElement as HTMLElement;
-        const trigger = wrapper.querySelector(
-          'button[aria-haspopup="listbox"]',
-        )!;
+        const trigger = screen.getByRole("button", {
+          name: new RegExp(`^${facet}\\b`, "i"),
+        });
         fireEvent.click(trigger);
         expect(screen.queryByTitle("Match any (OR)")).not.toBeInTheDocument();
         expect(screen.queryByTitle("Match all (AND)")).not.toBeInTheDocument();

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -178,10 +178,21 @@ const SearchSection: React.FC<SearchSectionProps> = ({
           menuWidthClassName="w-60"
         />
       </div>
-      <div className="mt-4 ml-1">
+      <div className="mt-4 ml-1 flex items-center justify-between gap-3">
         <p className="text-sm text-rmigray-500">
           Found {scenariosNumber} scenarios
           {areFiltersApplied && " matching your criteria"}
+          {areFiltersApplied && (
+            <button
+              type="button"
+              aria-label="Clear all filters"
+              className="ml-2 text-sm text-indigo-600 hover:underline focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded"
+              onClick={onClear}
+              data-testid="clear-all-filters"
+            >
+              Clear all filters
+            </button>
+          )}
         </p>
       </div>
     </div>

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -153,6 +153,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({
           showModeToggle
           mode={filters.modes?.geography ?? "ANY"}
           onModeChange={(m) => setMode("geography", m)}
+          menuWidthClassName="w-60"
         />
 
         <MultiSelectDropdown<string>
@@ -163,6 +164,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({
           showModeToggle
           mode={filters.modes?.sector ?? "ANY"}
           onModeChange={(m) => setMode("sector", m)}
+          menuWidthClassName="w-60"
         />
 
         <MultiSelectDropdown<string>
@@ -173,6 +175,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({
           showModeToggle
           mode={filters.modes?.metric ?? "ANY"}
           onModeChange={(m) => setMode("metric", m)}
+          menuWidthClassName="w-60"
         />
       </div>
       <div className="mt-4 ml-1">

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -126,30 +126,25 @@ describe("HomePage integration: dropdowns render and filter with 'None'", () => 
   }
 
   async function openDropdown(labelRegex: RegExp): Promise<HTMLButtonElement> {
-    // Multiple nodes can match the regex (e.g., scenario cards: "no sectors"/"no temp").
-    // Pick the *label* whose parent contains the dropdown trigger button.
-    const labels = await screen.findAllByText(
-      labelRegex,
-      {},
+    // Labels are now inside the trigger button’s accessible name (e.g., "Sector..." / "Sector: 2").
+    const triggers = await screen.findAllByRole(
+      "button",
+      { name: labelRegex },
       { timeout: 2000 },
     );
-    const label = labels.find((el) =>
-      el.parentElement?.querySelector('button[aria-haspopup="listbox"]'),
-    );
-    if (!label) {
-      // Helpful debug if this ever fails in CI
-      const all = labels.map((n) => `"${n.textContent}"`).join(", ");
+    const trigger =
+      triggers.find((b) => b.getAttribute("aria-haspopup") === "listbox") ??
+      triggers[0];
+    if (!trigger) {
+      const all = (await screen.findAllByRole("button"))
+        .map((n) => `"${n.textContent}"`)
+        .join(", ");
       throw new Error(
-        `Dropdown label not found for ${labelRegex}. Candidates: ${all}`,
+        `Dropdown trigger not found for ${labelRegex}. Button candidates: ${all}`,
       );
     }
-    const trigger = label.parentElement!.querySelector(
-      'button[aria-haspopup="listbox"]',
-    );
-    if (!trigger)
-      throw new Error(`Trigger button not found for ${label.textContent}`);
     await u.click(trigger);
-    return trigger;
+    return trigger as HTMLButtonElement;
   }
 
   async function selectOption(optionText: string): Promise<void> {


### PR DESCRIPTION
Update Multiselect Dropdown UI

### Summary of changes

- **Dropdown trigger redesign**
  - Moved facet labels inside the trigger button text (e.g., `Sector…`, `Sector: 3`).
  - Added count display with bold number and reserved width so the trigger doesn’t resize.
  - Swapped caret for a clear “X” icon when active, in a fixed-width slot to prevent layout shift.

- **Menu header updates**
  - Left side: *Select all* (always single-line) and *Clear* actions (stackable if space is tight).
  - Right side: bordered, right-justified explainer block with two lines:
    - “Show scenarios matching”
    - ANY/ALL toggle + facet label.
  - Ensured a minimum menu width so header content stays readable.

- **Global filter controls**
  - Added inline **“Clear all filters”** action next to the results summary, shown only when filters are active.

- **Accessibility / UX polish**
  - Maintained consistent trigger affordance width (chevron vs X).
  - Preserved focus/keyboard support (`aria-haspopup`, `Escape` to close, etc.).
  - Tests updated to target triggers by accessible name (no brittle text lookups).


Closes #410

Jira: https://rmi1.atlassian.net/browse/PBTAR-56