### PR TITLE
fix(dropdown): toggle any/all behavior on full target

### DIFF
--- a/src/components/MultiSelectDropdown.tsx
+++ b/src/components/MultiSelectDropdown.tsx
@@ -239,35 +239,41 @@ export default function MultiSelectDropdown<
                   </div>
                   <div
                     className="mt-1 flex items-center justify-end gap-1"
-                    role="group"
-                    aria-label="Match mode"
                     data-testid="mode-explainer"
                   >
-                    <div className="border border-gray-200 rounded-md">
-                      <button
-                        type="button"
+                    <div
+                      className="border border-gray-200 rounded-md cursor-pointer select-none"
+                      data-testid="mode-toggle"
+                      role="button"
+                      aria-label={`Toggle match mode (currently ${mode === "ANY" ? "Any" : "All"})`}
+                      aria-live="polite"
+                      tabIndex={0}
+                      onClick={() =>
+                        onModeChange?.(mode === "ANY" ? "ALL" : "ANY")
+                      }
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          onModeChange?.(mode === "ANY" ? "ALL" : "ANY");
+                        }
+                      }}
+                    >
+                      <span
                         className={clsx(
                           "px-[2px] py-[2px] rounded",
                           mode === "ANY" && "bg-gray-100",
                         )}
-                        onClick={() => onModeChange("ANY")}
-                        aria-pressed={mode === "ANY"}
-                        title="Match any (OR)"
                       >
                         Any
-                      </button>
-                      <button
-                        type="button"
+                      </span>
+                      <span
                         className={clsx(
                           "px-[2px] py-[2px] rounded",
                           mode === "ALL" && "bg-gray-100",
                         )}
-                        onClick={() => onModeChange("ALL")}
-                        aria-pressed={mode === "ALL"}
-                        title="Match all (AND)"
                       >
                         All
-                      </button>
+                      </span>
                     </div>
                     <span>selected</span>
                   </div>

--- a/src/components/SearchSection.test.tsx
+++ b/src/components/SearchSection.test.tsx
@@ -130,7 +130,7 @@ describe("SearchSection", () => {
     render(<SearchSection {...defaultProps} />);
     const trigger = screen.getByRole("button", { name: /^Geography\b/i });
     fireEvent.click(trigger);
-    fireEvent.click(screen.getByTitle("Match all (AND)"));
+    fireEvent.click(screen.getByTestId("mode-toggle"));
     expect(defaultProps.onFilterChange).toHaveBeenCalledWith("modes", {
       geography: "ALL",
     });
@@ -144,7 +144,7 @@ describe("SearchSection", () => {
     render(<SearchSection {...props} />);
     const trigger = screen.getByRole("button", { name: /^Sector\b/i });
     fireEvent.click(trigger);
-    fireEvent.click(screen.getByTitle("Match any (OR)"));
+    fireEvent.click(screen.getByTestId("mode-toggle"));
     expect(defaultProps.onFilterChange).toHaveBeenCalledWith("modes", {
       sector: "ANY",
     });

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -255,7 +255,7 @@ describe("HomePage integration: dropdowns render and filter with 'None'", () => 
     ]);
 
     // Switch to ALL inside the open menu
-    await u.click(screen.getByTitle("Match all (AND)"));
+    await u.click(screen.getByTestId("mode-toggle"));
     // Only E has both Europe and Asia
     expectVisible(["Scenario E (Power, Europe+Asia, 2°C)"]);
     expectHidden([
@@ -283,7 +283,7 @@ describe("HomePage integration: dropdowns render and filter with 'None'", () => 
     ]);
 
     // Switch to ALL inside the open menu
-    await u.click(screen.getByTitle("Match all (AND)"));
+    await u.click(screen.getByTestId("mode-toggle"));
     // ALL
     expectVisible(["Scenario D (Industry, Asia, no temp)"]);
     expectHidden([


### PR DESCRIPTION
Do not enforce clicking "any" or "all", but rather the entire bordered "pill" serves as a click target to toggle behavior, and the contents show the current status.

Closes #424