### PR TITLE
build(semantic release): exclude `style`, include `chore`

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
       [
         "@semantic-release/commit-analyzer",
         {
-          "preset": "angular",
+          "preset": "conventionalcommits",
           "releaseRules": [
             {
               "type": "build",
@@ -113,8 +113,12 @@
               "release": "patch"
             },
             {
+              "type": "chore",
+              "release": false
+            },
+            {
               "type": "style",
-              "release": "patch"
+              "release": false
             },
             {
               "type": "test",
@@ -167,11 +171,16 @@
               {
                 "type": "style",
                 "section": "Style",
-                "hidden": false
+                "hidden": true
               },
               {
                 "type": "test",
                 "section": "Tests",
+                "hidden": false
+              },
+              {
+                "type": "chore",
+                "section": "Other",
                 "hidden": false
               }
             ]


### PR DESCRIPTION
`chore` prefixes do not trigger a release, but do show up in release notes (in "Other"), while `style` (i.e `style: prettier`) neither triggers, nor appears in notes (expect many `style` changes)

closes #365