### PR TITLE
fix(data): backfill IEA scenario metadata with new schema fields

### DIFF
--- a/src/data/iea_metadata.json
+++ b/src/data/iea_metadata.json
@@ -72,7 +72,35 @@
       "Generation",
       "Technology Mix",
       "Absolute Emissions"
-    ]
+    ],
+    "keyFeatures": {
+      "emissionsPathway": "Fast decline",
+      "energyEfficiency": "Significant improvements",
+      "energyDemand": "Static energy demand",
+      "electrification": "Significant increase",
+      "policyTypes": [
+        "Carbon price",
+        "Phaseout dates",
+        "Subsidies",
+        "Target technology shares",
+        "Other"
+      ],
+      "technologyCostTrend": "Other",
+      "technologyDeploymentTrend": "Significant deployment of new technologies",
+      "emissionsScope": "CO2",
+      "policyAmbition": "NDCs and long term commitments",
+      "technologyCostsDetail": "Capital costs/O&M/etc.",
+      "newTechnologiesIncluded": [
+        "CCUS",
+        "DAC",
+        "Green H2/ammonia",
+        "SAF",
+        "Battery storage"
+      ],
+      "supplyChain": "Dynamic upstream fuel/material prices",
+      "investmentNeeds": "Sector-level by upstream/in-stream/downstream",
+      "infrastructureRequirements": "By part of supply chain and maintenance/buildout"
+    }
   },
   {
     "id": "IEA-STEPS-2024",
@@ -147,6 +175,34 @@
       "Generation",
       "Technology Mix",
       "Absolute Emissions"
-    ]
+    ],
+    "keyFeatures": {
+      "emissionsPathway": "Moderate decline",
+      "energyEfficiency": "Moderate improvements",
+      "energyDemand": "Moderate growth",
+      "electrification": "Moderate increase",
+      "policyTypes": [
+        "Carbon price",
+        "Phaseout dates",
+        "Subsidies",
+        "Target technology shares",
+        "Other"
+      ],
+      "technologyCostTrend": "Other",
+      "technologyDeploymentTrend": "Moderate deployment of new technologies",
+      "emissionsScope": "CO2",
+      "policyAmbition": "Current/legislated policies",
+      "technologyCostsDetail": "Capital costs/O&M/etc.",
+      "newTechnologiesIncluded": [
+        "CCUS",
+        "DAC",
+        "Green H2/ammonia",
+        "SAF",
+        "Battery storage"
+      ],
+      "supplyChain": "Dynamic upstream fuel/material prices",
+      "investmentNeeds": "Sector-level by upstream/in-stream/downstream",
+      "infrastructureRequirements": "By part of supply chain and maintenance/buildout"
+    }
   }
 ]


### PR DESCRIPTION
Include schema fields introduced in PR #442 in IEA data.

Note that merging prior to #442 results in IEA data no longer validating in the schema, and "disappearing" (due to changes from #440). **This is expected**, and should not block merge (it would help to merge, so we could have a visible data set in #442)