### PR TITLE
ci(schema validation): Improve handling of JSON validation warnings

### DIFF
--- a/.github/workflows/node-json-schema.yml
+++ b/.github/workflows/node-json-schema.yml
@@ -20,9 +20,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Set VITE_INCLUDE_INVALID
+        id: set-include
+        if: ${{ github.event_name == 'pull_request' && github.head_ref != 'production'}}
+        run: |
+          echo "vite-include-invalid=true" >> $GITHUB_OUTPUT
+
       - name: Run ajv JSON validator
         env:
-          VITE_INCLUDE_INVALID: ${{ (github.event_name == 'pull_request' && github.head_ref == 'production') && 'true' || 'false'}}
+          VITE_INCLUDE_INVALID: ${{ steps.set-include.output.vite-include-invalid }}
         run: npm run json:check
 
   schema-docs:

--- a/.github/workflows/node-json-schema.yml
+++ b/.github/workflows/node-json-schema.yml
@@ -21,6 +21,8 @@ jobs:
         run: npm ci
 
       - name: Run ajv JSON validator
+        env:
+          VITE_INCLUDE_INVALID: ${{ github.event_name == 'pull_request' && github.head_ref == 'production' && 'true' || 'false'}}
         run: npm run json:check
 
   schema-docs:

--- a/.github/workflows/node-json-schema.yml
+++ b/.github/workflows/node-json-schema.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Run ajv JSON validator
         env:
-          VITE_INCLUDE_INVALID: ${{ github.event_name == 'pull_request' && github.head_ref == 'production' && 'true' || 'false'}}
+          VITE_INCLUDE_INVALID: ${{ (github.event_name == 'pull_request' && github.head_ref == 'production') && 'true' || 'false'}}
         run: npm run json:check
 
   schema-docs:

--- a/.github/workflows/node-json-schema.yml
+++ b/.github/workflows/node-json-schema.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run ajv JSON validator
         env:
-          VITE_INCLUDE_INVALID: ${{ steps.set-include.output.vite-include-invalid }}
+          VITE_INCLUDE_INVALID: ${{ steps.set-include.outputs.vite-include-invalid }}
         run: npm run json:check
 
   schema-docs:

--- a/.github/workflows/node-json-schema.yml
+++ b/.github/workflows/node-json-schema.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Set VITE_INCLUDE_INVALID
         id: set-include
-        if: ${{ github.event_name == 'pull_request' && github.head_ref != 'production'}}
+        if: ${{ github.event_name == 'pull_request' && github.base_ref != 'production'}}
         run: |
           echo "vite-include-invalid=true" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/node-json-schema.yml
+++ b/.github/workflows/node-json-schema.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Set VITE_INCLUDE_INVALID
         id: set-include
-        if: ${{ github.event_name == 'pull_request' && github.base_ref != 'production'}}
+        if: ${{ github.event_name == 'pull_request' && github.base_ref != 'production' }}
         run: |
           echo "vite-include-invalid=true" >> $GITHUB_OUTPUT
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "format:watch": "chokidar . --ignore \".git/**\" --ignore \"node_modules/**\" -c \"prettier --check .\"",
-    "json:check": "npm run json:check:srcdata && npm run json:check:testdata",
+    "json:check": "npx ts-node --esm scripts/schema-check-files.ts src/data testdata/valid",
     "json:check:srcdata": "npx ts-node --esm scripts/schema-check-files.ts src/data",
     "json:check:testdata": "npx ts-node --esm scripts/schema-check-files.ts testdata/valid",
     "docs:jsonSchema": "scripts/generate-schema-docs.sh",

--- a/scripts/schema-check-files.ts
+++ b/scripts/schema-check-files.ts
@@ -1,13 +1,12 @@
+// scripts/schema-check-files.ts
 import { promises as fs } from "node:fs";
 import { join } from "node:path";
 import type { FileEntry } from "../src/utils/validateScenarios.ts";
-import {
-  assembleScenarios,
-  decideIncludeInvalid,
-} from "../src/utils/loadScenarios.ts";
+import { validateScenariosCollect } from "../src/utils/validateScenarios.ts";
+import { decideIncludeInvalid } from "../src/utils/loadScenarios.ts";
 
-async function main() {
-  const dir = process.argv[2] ?? "src/data"; // default if not provided
+async function run(dir: string) {
+
   const names = (await fs.readdir(dir)).filter((f) => f.endsWith(".json"));
 
   const entries: FileEntry[] = [];
@@ -16,30 +15,73 @@ async function main() {
     entries.push({ name, data: JSON.parse(raw) });
   }
 
-  const includeInvalid = decideIncludeInvalid();
+  const { valid, invalid } = validateScenariosCollect(entries);
+  return { dir, validCount: valid.length, invalid };
+}
 
-  const scenarios = assembleScenarios(entries, {
-    includeInvalid,
-    warn: (msg: string) => console.warn(msg),
-  });
-  // Check for invalid scenarios
-  const invalidScenarios = scenarios.filter((s: any) => s && s.valid === false);
-  if (invalidScenarios.length > 0) {
-    console.error(
-      `✖ Found ${invalidScenarios.length} invalid scenario(s) in ${dir}:`,
-    );
-    for (const s of invalidScenarios) {
-      console.error(`  - ${s.name || "(unnamed scenario)"}`);
+async function main() {
+  const args = process.argv.slice(2);
+  const dirs = args.length ? args : ["src/data"]; // default if none provided
+  const strict = !decideIncludeInvalid();
+  const inCI =
+    String(process.env.GITHUB_ACTIONS || "").toLowerCase() === "true";
+
+  let totalValid = 0;
+  let totalInvalid = 0;
+
+  const results = await Promise.all(dirs.map(run));
+
+  // Emit human summary + GH annotations (without failing yet)
+  for (const r of results) {
+    totalValid += r.validCount;
+    totalInvalid += r.invalid.length;
+
+    if (r.invalid.length === 0) {
+      // eslint-disable-next-line no-console
+      console.log(`✔ ${r.dir}: OK (${r.validCount} items)`);
+      continue;
     }
-    process.exit(1);
-  } else {
-    console.log(
-      `✔ Validated ${names.length} data file(s) from ${dir} against schema.`,
+
+    // eslint-disable-next-line no-console
+    console.error(
+      `✖ ${r.dir}: ${r.invalid.length} schema-invalid file(s) found:`,
     );
+
+    for (const p of r.invalid) {
+      // Emit up to N errors per file as GH annotations
+      const file = join(r.dir, p.name);
+      const errs = p.errors.slice(0, 50);
+      for (const e of errs) {
+        // eslint-disable-next-line no-console
+        console.log(`::warning file=${file}::${e}`);
+      }
+      if (p.errors.length > errs.length) {
+        // eslint-disable-next-line no-console
+        console.log(
+          `::notice file=${file}::…and ${
+            p.errors.length - errs.length
+          } more error(s)`,
+        );
+      }
+    }
+  }
+
+  // Final summary
+  // eslint-disable-next-line no-console
+  console.log(
+    `\nSummary: ${totalValid} valid item(s), ${totalInvalid} invalid file(s) across ${dirs.length} director${
+      dirs.length === 1 ? "y" : "ies"
+    }.`,
+  );
+
+  // Optional failure gate
+  if (strict && totalInvalid > 0) {
+    process.exit(1);
   }
 }
 
 main().catch((e) => {
+  // eslint-disable-next-line no-console
   console.error(String(e?.stack || e));
   process.exit(1);
 });


### PR DESCRIPTION
Closes #447 

* Update schema validation script to use `VITE_INCLUDE_INVALID` as a flag to not fail the schema check on scanning invalid scenarios
* Update GH workflow to set `VITE_INCLUDE_INVALID=true` on PRs to main
* Update package.json script to call script once, rather than sequentially