### PR TITLE
Import d3-transition in NormalizedStackedAreaChart

### DIFF
--- a/src/components/NormalizedStackedAreaChart.tsx
+++ b/src/components/NormalizedStackedAreaChart.tsx
@@ -6,6 +6,7 @@ import { group } from "d3-array";
 import { extent } from "d3-array";
 import { axisBottom, axisLeft } from "d3-axis";
 import { stackOffsetExpand } from "d3-shape";
+import "d3-transition";
 import { useRef, useEffect, useState, useMemo } from "react";
 import { capitalizeWords } from "../utils/capitalizeWords";
 


### PR DESCRIPTION
NormalizedStackedAreaChart uses d3-transition but does not import it explicitly, benefitting from the fact that VerticalBarChart imports it, but if there's not a VerticalBarChart on the page then NormalizedStackedAreaChart errors because d3-transition is not loaded.