### PR TITLE
ci(rulesets): remove key to match GH format

### DIFF
--- a/.github/rulesets/gitflow-main.json
+++ b/.github/rulesets/gitflow-main.json
@@ -30,7 +30,6 @@
         "require_code_owner_review": true,
         "require_last_push_approval": true,
         "required_review_thread_resolution": false,
-        "automatic_copilot_code_review_enabled": false,
         "allowed_merge_methods": ["merge"]
       }
     },

--- a/.github/rulesets/gitflow-next-pr.json
+++ b/.github/rulesets/gitflow-next-pr.json
@@ -26,7 +26,6 @@
         "require_code_owner_review": true,
         "require_last_push_approval": true,
         "required_review_thread_resolution": true,
-        "automatic_copilot_code_review_enabled": false,
         "allowed_merge_methods": ["merge"]
       }
     }

--- a/.github/rulesets/gitflow-production.json
+++ b/.github/rulesets/gitflow-production.json
@@ -30,7 +30,6 @@
         "require_code_owner_review": true,
         "require_last_push_approval": true,
         "required_review_thread_resolution": true,
-        "automatic_copilot_code_review_enabled": false,
         "allowed_merge_methods": ["merge"]
       }
     },


### PR DESCRIPTION
removes code review key from rulesets, to match push in GH's API