### PR TITLE
feat(colophon): Add colophon in footer (expand copyright line)

### DIFF
--- a/src/components/Colophon.tsx
+++ b/src/components/Colophon.tsx
@@ -3,6 +3,7 @@ import { Copy, Check } from "lucide-react";
 
 interface ColophonProps {
   className?: string;
+  trigger?: React.ReactNode;
 }
 
 interface SystemInfo {
@@ -22,7 +23,10 @@ interface NetworkInformation {
   };
 }
 
-const Colophon: React.FC<ColophonProps> = ({ className = "" }) => {
+const Colophon: React.FC<ColophonProps> = ({
+  className = "",
+  trigger = "Build and System Information",
+}) => {
   const [systemInfo, setSystemInfo] = useState<SystemInfo>({
     userAgent: "Loading...",
     screenResolution: "Loading...",
@@ -128,10 +132,8 @@ const Colophon: React.FC<ColophonProps> = ({ className = "" }) => {
   };
 
   return (
-    <details className={`text-sm text-rmigray-500 ${className}`}>
-      <summary className="cursor-pointer hover:text-rmigray-700">
-        Build and System Information
-      </summary>
+    <details className={className}>
+      <summary className="cursor-pointer">{trigger}</summary>
       <div className="mt-2">
         <button
           onClick={(e) => {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Mail } from "lucide-react";
+import Colophon from "../components/Colophon";
 
 const Footer: React.FC = () => {
   return (
@@ -32,9 +33,10 @@ const Footer: React.FC = () => {
         </div>
 
         <div className="mt-4 pt-4 border-t border-basalt text-center">
-          <p className="text-xs text-white">
-            &copy; {new Date().getFullYear()} RMI. All rights reserved.
-          </p>
+          <Colophon
+            className="inline-block text-xs text-white"
+            trigger={`© ${new Date().getFullYear()} RMI. All rights reserved.`}
+          />
         </div>
       </div>
     </footer>


### PR DESCRIPTION
Adds the colophon to the footer (following its removal with the "about" page), hiding it in the copyright statement, which when clicked, expands the footer to show the colophon System/build info

<img width="524" height="118" alt="Screenshot_2025-12-05_10 26 35@2x" src="https://github.com/user-attachments/assets/778477e8-df33-407e-93c6-800525e5c679" />
<img width="802" height="506" alt="Screenshot_2025-12-05_10 26 55@2x" src="https://github.com/user-attachments/assets/962c17d7-caa3-4880-9f29-2820b80c09e2" />

