### PR TITLE
feat: remove stray full stop in sbs guide

### DIFF
--- a/src/components/StepByStepGuide.tsx
+++ b/src/components/StepByStepGuide.tsx
@@ -90,7 +90,7 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
       "Direct Policy": "Sourced directly from policy frameworks",
       "Exploratory": "Future states under explicit assumptions",
       "Normative": "Pre-determined target outcome",
-      "Predictive": "Extrapolates from current trends.",
+      "Predictive": "Extrapolates from current trends",
     },
     emissionsTrajectory: {
       "Significant increase": "Grow more than 50% by 2050",


### PR DESCRIPTION
- removes a stray full stop in the description of the pathway types in the SBS guide