### PR TITLE
fix(colophon): colophon shows correct app version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "npm run prepare:tarball"
+          "prepareCmd": "VITE_APP_VERSION=${nextRelease.version} npm run prepare:tarball"
         }
       ],
       [

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "VITE_APP_VERSION=${nextRelease.version} npm run prepare:tarball"
+          "prepareCmd": "cross-env VITE_APP_VERSION=${nextRelease.version} npm run prepare:tarball"
         }
       ],
       [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,11 +91,16 @@ function buildInfoPlugin(): Plugin {
       const gitInfo = await getGitInfo();
       const osInfo = getOsInfo();
       const pkgVersion = (pkg as { version: string | undefined }).version;
+      const appVersion =
+        // CI / releases: injected by semantic-release exec plugin
+        process.env.VITE_APP_VERSION ||
+        // Local dev / fallback
+        pkgVersion;
 
       return {
         define: {
           // Build Env
-          "import.meta.env.VITE_APP_VERSION": JSON.stringify(pkgVersion),
+          "import.meta.env.VITE_APP_VERSION": JSON.stringify(appVersion),
           "import.meta.env.VITE_NODE_VERSION": JSON.stringify(process.version),
           "import.meta.env.VITE_VERSION": JSON.stringify(viteVersion),
           "import.meta.env.VITE_ENVIRONMENT": JSON.stringify(mode),


### PR DESCRIPTION
removing the `@semantic-release/npm` block from package.json in #635 (merge commit `6919803`) eliminated the mechanism by which the version was updated in `package.json` (and then read by the app).

This change allows setting the version using an ENVVAR, and then setting that during the `exec` phase when preparing the site tarball.

Closes #680

<img width="513" height="230" alt="Screenshot_2025-12-09_10 21 14" src="https://github.com/user-attachments/assets/b6ad15bc-fff4-4caf-9cd4-0d69f8f080cc" />
