### PR TITLE
feat: update landing page and add resource pages

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,11 +1,26 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { AppContent } from "./App";
 
 vi.mock("./pages/LandingPage", () => ({
   default: () => <div data-testid="mock-homepage">LandingPage</div>,
 }));
+
+vi.mock("./pages/resources", () => ({
+  ResourcesFaqPage: () => <div>Faq Page</div>,
+  ResourcesHowToChooseAPathwayPage: () => (
+    <div data-testid="mock-how-to-choose-page">How To Choose A Pathway</div>
+  ),
+  ResourcesMethodologyPage: () => <div>Methodology Page</div>,
+  ResourcesUpdatesPage: () => <div>Updates Page</div>,
+  ResourcesUseCasesPage: () => <div>Use Cases Page</div>,
+}));
+
+const LocationDisplay = () => {
+  const location = useLocation();
+  return <div data-testid="location-display">{location.pathname}</div>;
+};
 
 describe("App component", () => {
   it("renders the LandingPage component", () => {
@@ -15,5 +30,19 @@ describe("App component", () => {
       </MemoryRouter>,
     );
     expect(screen.getByTestId("mock-homepage")).toBeInTheDocument();
+  });
+
+  it("renders the canonical how-to-choose-a-pathway route", () => {
+    render(
+      <MemoryRouter initialEntries={["/resources/how-to-choose-a-pathway"]}>
+        <AppContent />
+        <LocationDisplay />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("mock-how-to-choose-page")).toBeInTheDocument();
+    expect(screen.getByTestId("location-display")).toHaveTextContent(
+      "/resources/how-to-choose-a-pathway",
+    );
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,15 @@ import LegalPage from "./pages/LegalPage";
 import PathwaySearch from "./pages/PathwaySearch";
 import PathwayDetailPage from "./pages/PathwayDetailPage";
 import LandingPage from "./pages/LandingPage";
+import ContactPage from "./pages/ContactPage";
 import EnvironmentBanner from "./components/EnvironmentBanner";
+import {
+  ResourcesFaqPage,
+  ResourcesHowToChooseAPathwayPage,
+  ResourcesMethodologyPage,
+  ResourcesUpdatesPage,
+  ResourcesUseCasesPage,
+} from "./pages/resources";
 
 // Export the inner content for testing
 export const AppContent = () => {
@@ -35,6 +43,32 @@ export const AppContent = () => {
           <Route
             path="/legal"
             element={<LegalPage />}
+          />
+
+          <Route
+            path="/contact"
+            element={<ContactPage />}
+          />
+
+          <Route
+            path="/resources/methodology"
+            element={<ResourcesMethodologyPage />}
+          />
+          <Route
+            path="/resources/how-to-choose-a-pathway"
+            element={<ResourcesHowToChooseAPathwayPage />}
+          />
+          <Route
+            path="/resources/faq"
+            element={<ResourcesFaqPage />}
+          />
+          <Route
+            path="/resources/use-cases"
+            element={<ResourcesUseCasesPage />}
+          />
+          <Route
+            path="/resources/updates"
+            element={<ResourcesUpdatesPage />}
           />
         </Routes>
       </main>

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import Header from "./Header";
 
@@ -28,5 +29,33 @@ describe("Header component", () => {
     renderHeader();
     const logo = screen.getByAltText("RMI logo");
     expect(logo).toBeInTheDocument();
+  });
+
+  it("shows Resources dropdown links", async () => {
+    renderHeader();
+    const user = userEvent.setup();
+
+    expect(
+      screen.getByRole("link", { name: "Contact Us" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /resources/i }));
+
+    const menuItems = screen.getAllByRole("menuitem");
+    expect(menuItems[0]).toHaveTextContent("How to choose a pathway");
+
+    expect(
+      screen.getByRole("menuitem", { name: "Methodology" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Use cases" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "How to choose a pathway" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "FAQs" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Updates" }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import Header from "./Header";
@@ -40,22 +40,27 @@ describe("Header component", () => {
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /resources/i }));
+    const resourcesNav = screen.getByRole("navigation", { name: "Resources" });
 
-    const menuItems = screen.getAllByRole("menuitem");
-    expect(menuItems[0]).toHaveTextContent("How to choose a pathway");
+    const menuLinks = within(resourcesNav).getAllByRole("link");
+    expect(menuLinks[0]).toHaveTextContent("How to choose a pathway");
 
     expect(
-      screen.getByRole("menuitem", { name: "Methodology" }),
+      within(resourcesNav).getByRole("link", { name: "Methodology" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("menuitem", { name: "Use cases" }),
+      within(resourcesNav).getByRole("link", { name: "Use cases" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("menuitem", { name: "How to choose a pathway" }),
+      within(resourcesNav).getByRole("link", {
+        name: "How to choose a pathway",
+      }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("menuitem", { name: "FAQs" })).toBeInTheDocument();
     expect(
-      screen.getByRole("menuitem", { name: "Updates" }),
+      within(resourcesNav).getByRole("link", { name: "FAQs" }),
+    ).toBeInTheDocument();
+    expect(
+      within(resourcesNav).getByRole("link", { name: "Updates" }),
     ).toBeInTheDocument();
   });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 
-export const HeaderBrand: React.FC = () => {
+export const HeaderBrand: React.FC<{ to?: string }> = ({ to = "/" }) => {
   return (
     <Link
-      to="/pathway"
+      to={to}
       className="flex items-center space-x-3 group transition-all duration-300"
     >
       <div>
@@ -25,10 +25,99 @@ export const HeaderBrand: React.FC = () => {
 };
 
 const Header: React.FC = () => {
+  const [resourcesOpen, setResourcesOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!resourcesOpen) return;
+    const onDocClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (menuRef.current && !menuRef.current.contains(target)) {
+        setResourcesOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [resourcesOpen]);
+
   return (
-    <header className="bg-bluespruce text-white shadow-md">
+    <header className="relative z-50 bg-bluespruce text-white shadow-md">
       <div className="container mx-auto px-4 py-4 flex flex-col md:flex-row justify-between items-center">
         <HeaderBrand />
+
+        <nav className="mt-3 md:mt-0 flex items-center gap-2">
+          <Link
+            to="/contact"
+            className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-white/90 hover:text-white hover:bg-white/10 transition-colors"
+          >
+            Contact Us
+          </Link>
+
+          <div
+            ref={menuRef}
+            className="relative"
+          >
+            <button
+              type="button"
+              className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-white/90 hover:text-white hover:bg-white/10 transition-colors"
+              aria-haspopup="menu"
+              aria-expanded={resourcesOpen}
+              onClick={() => setResourcesOpen((v) => !v)}
+            >
+              Resources
+              <span className="text-white/70">▾</span>
+            </button>
+
+            {resourcesOpen && (
+              <div
+                role="menu"
+                className="absolute right-0 z-[60] mt-2 w-72 overflow-hidden rounded-md bg-white text-rmigray-800 shadow-lg ring-1 ring-black/5"
+              >
+                <Link
+                  role="menuitem"
+                  to="/resources/how-to-choose-a-pathway"
+                  className="block px-4 py-3 text-sm hover:bg-neutral-100"
+                  onClick={() => setResourcesOpen(false)}
+                >
+                  How to choose a pathway
+                </Link>
+                <Link
+                  role="menuitem"
+                  to="/resources/use-cases"
+                  className="block px-4 py-3 text-sm hover:bg-neutral-100"
+                  onClick={() => setResourcesOpen(false)}
+                >
+                  Use cases
+                </Link>
+                <Link
+                  role="menuitem"
+                  to="/resources/methodology"
+                  className="block px-4 py-3 text-sm hover:bg-neutral-100"
+                  onClick={() => setResourcesOpen(false)}
+                >
+                  Methodology
+                </Link>
+                <Link
+                  role="menuitem"
+                  to="/resources/updates"
+                  className="block px-4 py-3 text-sm hover:bg-neutral-100"
+                  onClick={() => setResourcesOpen(false)}
+                >
+                  Updates
+                </Link>
+                <Link
+                  role="menuitem"
+                  to="/resources/faq"
+                  className="block px-4 py-3 text-sm hover:bg-neutral-100"
+                  onClick={() => setResourcesOpen(false)}
+                >
+                  FAQs
+                </Link>
+              </div>
+            )}
+          </div>
+        </nav>
       </div>
     </header>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 import { Link } from "react-router-dom";
+import HeaderNav from "./HeaderNav";
 
 export const HeaderBrand: React.FC<{ to?: string }> = ({ to = "/" }) => {
   return (
@@ -25,99 +26,11 @@ export const HeaderBrand: React.FC<{ to?: string }> = ({ to = "/" }) => {
 };
 
 const Header: React.FC = () => {
-  const [resourcesOpen, setResourcesOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!resourcesOpen) return;
-    const onDocClick = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (menuRef.current && !menuRef.current.contains(target)) {
-        setResourcesOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", onDocClick);
-    return () => document.removeEventListener("mousedown", onDocClick);
-  }, [resourcesOpen]);
-
   return (
     <header className="relative z-50 bg-bluespruce text-white shadow-md">
       <div className="container mx-auto px-4 py-4 flex flex-col md:flex-row justify-between items-center">
         <HeaderBrand />
-
-        <nav className="mt-3 md:mt-0 flex items-center gap-2">
-          <Link
-            to="/contact"
-            className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-white/90 hover:text-white hover:bg-white/10 transition-colors"
-          >
-            Contact Us
-          </Link>
-
-          <div
-            ref={menuRef}
-            className="relative"
-          >
-            <button
-              type="button"
-              className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-white/90 hover:text-white hover:bg-white/10 transition-colors"
-              aria-haspopup="menu"
-              aria-expanded={resourcesOpen}
-              onClick={() => setResourcesOpen((v) => !v)}
-            >
-              Resources
-              <span className="text-white/70">▾</span>
-            </button>
-
-            {resourcesOpen && (
-              <div
-                role="menu"
-                className="absolute right-0 z-[60] mt-2 w-72 overflow-hidden rounded-md bg-white text-rmigray-800 shadow-lg ring-1 ring-black/5"
-              >
-                <Link
-                  role="menuitem"
-                  to="/resources/how-to-choose-a-pathway"
-                  className="block px-4 py-3 text-sm hover:bg-neutral-100"
-                  onClick={() => setResourcesOpen(false)}
-                >
-                  How to choose a pathway
-                </Link>
-                <Link
-                  role="menuitem"
-                  to="/resources/use-cases"
-                  className="block px-4 py-3 text-sm hover:bg-neutral-100"
-                  onClick={() => setResourcesOpen(false)}
-                >
-                  Use cases
-                </Link>
-                <Link
-                  role="menuitem"
-                  to="/resources/methodology"
-                  className="block px-4 py-3 text-sm hover:bg-neutral-100"
-                  onClick={() => setResourcesOpen(false)}
-                >
-                  Methodology
-                </Link>
-                <Link
-                  role="menuitem"
-                  to="/resources/updates"
-                  className="block px-4 py-3 text-sm hover:bg-neutral-100"
-                  onClick={() => setResourcesOpen(false)}
-                >
-                  Updates
-                </Link>
-                <Link
-                  role="menuitem"
-                  to="/resources/faq"
-                  className="block px-4 py-3 text-sm hover:bg-neutral-100"
-                  onClick={() => setResourcesOpen(false)}
-                >
-                  FAQs
-                </Link>
-              </div>
-            )}
-          </div>
-        </nav>
+        <HeaderNav />
       </div>
     </header>
   );

--- a/src/components/HeaderNav.test.tsx
+++ b/src/components/HeaderNav.test.tsx
@@ -11,9 +11,10 @@ describe("HeaderNav component", () => {
       </MemoryRouter>,
     );
 
-    expect(
-      screen.getByRole("link", { name: "Contact Us" }),
-    ).toHaveAttribute("href", "/contact");
+    expect(screen.getByRole("link", { name: "Contact Us" })).toHaveAttribute(
+      "href",
+      "/contact",
+    );
     expect(
       screen.getByRole("button", { name: /resources/i }),
     ).toBeInTheDocument();

--- a/src/components/HeaderNav.test.tsx
+++ b/src/components/HeaderNav.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import HeaderNav from "./HeaderNav";
+
+describe("HeaderNav component", () => {
+  it("renders the contact link and shared resources button", () => {
+    render(
+      <MemoryRouter>
+        <HeaderNav />
+      </MemoryRouter>,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Contact Us" }),
+    ).toHaveAttribute("href", "/contact");
+    expect(
+      screen.getByRole("button", { name: /resources/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/HeaderNav.tsx
+++ b/src/components/HeaderNav.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import ResourcesDropdown from "./ResourcesDropdown";
+
+const HeaderNav: React.FC = () => {
+  return (
+    <nav className="mt-3 flex items-center gap-2 md:mt-0">
+      <Link
+        to="/contact"
+        className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-white/90 transition-colors hover:bg-white/10 hover:text-white"
+      >
+        Contact Us
+      </Link>
+
+      <ResourcesDropdown />
+    </nav>
+  );
+};
+
+export default HeaderNav;

--- a/src/components/ResourcesDropdown.test.tsx
+++ b/src/components/ResourcesDropdown.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import ResourcesDropdown from "./ResourcesDropdown";
+
+describe("ResourcesDropdown component", () => {
+  const renderDropdown = () =>
+    render(
+      <MemoryRouter>
+        <ResourcesDropdown />
+      </MemoryRouter>,
+    );
+
+  it("shows the shared resource links when opened", async () => {
+    renderDropdown();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /resources/i }));
+
+    expect(
+      screen.getByRole("menuitem", { name: "How to choose a pathway" }),
+    ).toHaveAttribute("href", "/resources/how-to-choose-a-pathway");
+    expect(screen.getByRole("menuitem", { name: "Use cases" })).toHaveAttribute(
+      "href",
+      "/resources/use-cases",
+    );
+    expect(
+      screen.getByRole("menuitem", { name: "Methodology" }),
+    ).toHaveAttribute("href", "/resources/methodology");
+    expect(screen.getByRole("menuitem", { name: "Updates" })).toHaveAttribute(
+      "href",
+      "/resources/updates",
+    );
+    expect(screen.getByRole("menuitem", { name: "FAQs" })).toHaveAttribute(
+      "href",
+      "/resources/faq",
+    );
+  });
+
+  it("closes when clicking outside the menu", async () => {
+    renderDropdown();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /resources/i }));
+    expect(
+      screen.getByRole("menuitem", { name: "How to choose a pathway" }),
+    ).toBeInTheDocument();
+
+    await user.click(document.body);
+
+    expect(
+      screen.queryByRole("menuitem", { name: "How to choose a pathway" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("closes after clicking a menu item", async () => {
+    renderDropdown();
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: /resources/i }));
+    await user.click(
+      screen.getByRole("menuitem", { name: "How to choose a pathway" }),
+    );
+
+    expect(
+      screen.queryByRole("menuitem", { name: "How to choose a pathway" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ResourcesDropdown.test.tsx
+++ b/src/components/ResourcesDropdown.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import ResourcesDropdown from "./ResourcesDropdown";
@@ -17,25 +17,25 @@ describe("ResourcesDropdown component", () => {
     const user = userEvent.setup();
 
     await user.click(screen.getByRole("button", { name: /resources/i }));
+    const resourcesNav = screen.getByRole("navigation", { name: "Resources" });
 
     expect(
-      screen.getByRole("menuitem", { name: "How to choose a pathway" }),
+      within(resourcesNav).getByRole("link", {
+        name: "How to choose a pathway",
+      }),
     ).toHaveAttribute("href", "/resources/how-to-choose-a-pathway");
-    expect(screen.getByRole("menuitem", { name: "Use cases" })).toHaveAttribute(
-      "href",
-      "/resources/use-cases",
-    );
     expect(
-      screen.getByRole("menuitem", { name: "Methodology" }),
+      within(resourcesNav).getByRole("link", { name: "Use cases" }),
+    ).toHaveAttribute("href", "/resources/use-cases");
+    expect(
+      within(resourcesNav).getByRole("link", { name: "Methodology" }),
     ).toHaveAttribute("href", "/resources/methodology");
-    expect(screen.getByRole("menuitem", { name: "Updates" })).toHaveAttribute(
-      "href",
-      "/resources/updates",
-    );
-    expect(screen.getByRole("menuitem", { name: "FAQs" })).toHaveAttribute(
-      "href",
-      "/resources/faq",
-    );
+    expect(
+      within(resourcesNav).getByRole("link", { name: "Updates" }),
+    ).toHaveAttribute("href", "/resources/updates");
+    expect(
+      within(resourcesNav).getByRole("link", { name: "FAQs" }),
+    ).toHaveAttribute("href", "/resources/faq");
   });
 
   it("closes when clicking outside the menu", async () => {
@@ -44,13 +44,13 @@ describe("ResourcesDropdown component", () => {
 
     await user.click(screen.getByRole("button", { name: /resources/i }));
     expect(
-      screen.getByRole("menuitem", { name: "How to choose a pathway" }),
+      screen.getByRole("link", { name: "How to choose a pathway" }),
     ).toBeInTheDocument();
 
     await user.click(document.body);
 
     expect(
-      screen.queryByRole("menuitem", { name: "How to choose a pathway" }),
+      screen.queryByRole("navigation", { name: "Resources" }),
     ).not.toBeInTheDocument();
   });
 
@@ -60,11 +60,11 @@ describe("ResourcesDropdown component", () => {
 
     await user.click(screen.getByRole("button", { name: /resources/i }));
     await user.click(
-      screen.getByRole("menuitem", { name: "How to choose a pathway" }),
+      screen.getByRole("link", { name: "How to choose a pathway" }),
     );
 
     expect(
-      screen.queryByRole("menuitem", { name: "How to choose a pathway" }),
+      screen.queryByRole("navigation", { name: "Resources" }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/components/ResourcesDropdown.tsx
+++ b/src/components/ResourcesDropdown.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+
+const resourceMenuItems = [
+  {
+    label: "How to choose a pathway",
+    to: "/resources/how-to-choose-a-pathway",
+  },
+  { label: "Use cases", to: "/resources/use-cases" },
+  { label: "Methodology", to: "/resources/methodology" },
+  { label: "Updates", to: "/resources/updates" },
+  { label: "FAQs", to: "/resources/faq" },
+];
+
+const ResourcesDropdown: React.FC = () => {
+  const [resourcesOpen, setResourcesOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!resourcesOpen) return;
+
+    const onDocClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (menuRef.current && !menuRef.current.contains(target)) {
+        setResourcesOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [resourcesOpen]);
+
+  return (
+    <div
+      ref={menuRef}
+      className="relative"
+    >
+      <button
+        type="button"
+        className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-white/90 transition-colors hover:bg-white/10 hover:text-white"
+        aria-haspopup="menu"
+        aria-expanded={resourcesOpen}
+        onClick={() => setResourcesOpen((value) => !value)}
+      >
+        Resources
+        <span className="text-white/70">▾</span>
+      </button>
+
+      {resourcesOpen && (
+        <div
+          role="menu"
+          className="absolute right-0 z-[60] mt-2 w-72 overflow-hidden rounded-md bg-white text-rmigray-800 shadow-lg ring-1 ring-black/5"
+        >
+          {resourceMenuItems.map((item) => (
+            <Link
+              key={item.to}
+              role="menuitem"
+              to={item.to}
+              className="block px-4 py-3 text-sm hover:bg-neutral-100"
+              onClick={() => setResourcesOpen(false)}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ResourcesDropdown;

--- a/src/components/ResourcesDropdown.tsx
+++ b/src/components/ResourcesDropdown.tsx
@@ -38,7 +38,6 @@ const ResourcesDropdown: React.FC = () => {
       <button
         type="button"
         className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-white/90 transition-colors hover:bg-white/10 hover:text-white"
-        aria-haspopup="menu"
         aria-expanded={resourcesOpen}
         onClick={() => setResourcesOpen((value) => !value)}
       >
@@ -47,14 +46,13 @@ const ResourcesDropdown: React.FC = () => {
       </button>
 
       {resourcesOpen && (
-        <div
-          role="menu"
+        <nav
+          aria-label="Resources"
           className="absolute right-0 z-[60] mt-2 w-72 overflow-hidden rounded-md bg-white text-rmigray-800 shadow-lg ring-1 ring-black/5"
         >
           {resourceMenuItems.map((item) => (
             <Link
               key={item.to}
-              role="menuitem"
               to={item.to}
               className="block px-4 py-3 text-sm hover:bg-neutral-100"
               onClick={() => setResourcesOpen(false)}
@@ -62,7 +60,7 @@ const ResourcesDropdown: React.FC = () => {
               {item.label}
             </Link>
           ))}
-        </div>
+        </nav>
       )}
     </div>
   );

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -41,19 +41,19 @@ const ContactPage: React.FC = () => {
               collaboration.
             </p>
             <p className="mt-4 text-rmigray-700 leading-7">
-              To get in touch, reach out to Tom White or Nayra Herrera at{" "}
+              To get in touch, reach out to{" "}
               <a
                 href="mailto:tomwhite+pbtar@rmi.org"
                 className="text-energy-700 underline underline-offset-2 hover:text-energy-800"
               >
-                tomwhite@rmi.org
+                Tom White
               </a>{" "}
-              and{" "}
+               or{" "}
               <a
                 href="mailto:nherrera+pbtar@rmi.org"
                 className="text-energy-700 underline underline-offset-2 hover:text-energy-800"
               >
-                nherrera@rmi.org
+                Nayra Herrera
               </a>
               , or open an issue on our{" "}
               <a

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+
+const ContactPage: React.FC = () => {
+  return (
+    <div className="bg-gray-50">
+      <div className="container mx-auto px-4 py-8 md:py-10">
+        <section className="relative overflow-hidden rounded-[1.75rem] bg-rmiblue-800 px-6 py-8 text-white shadow-lg md:px-10 md:py-10">
+          <div className="absolute inset-0 bg-gradient-to-br from-white/8 via-transparent to-energy-700/10" />
+          <div className="absolute -right-10 top-0 h-32 w-32 rounded-full bg-white/7 blur-2xl" />
+          <div className="absolute bottom-0 left-0 h-36 w-36 rounded-full bg-energy-500/8 blur-2xl" />
+
+          <div className="relative">
+            <h1 className="text-3xl font-bold tracking-tight md:text-4xl">
+              Contact
+            </h1>
+
+            <div className="mt-6 space-y-4 text-sm leading-7 text-white/85 md:text-base">
+              <p>
+                We are building the Transition Pathways Repository to support
+                informed transition-related decisions by making pathway data
+                easier to access, understand, and apply.
+              </p>
+              <p>
+                We actively engage with financial institutions, companies,
+                policymakers, and other stakeholders to refine the tool, expand
+                its coverage, and improve its usability. Whether you are using
+                pathways in analysis, strategy, risk management, or policy
+                development, your input helps shape how the repository evolves.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-12 max-w-5xl rounded-[2rem] border border-rmiblue-100 bg-rmiblue-50/60 px-6 py-8 shadow-sm md:px-8 md:py-10">
+          <div className="max-w-5xl">
+            <h2 className="text-2xl font-semibold text-rmigray-800">
+              How to reach us
+            </h2>
+            <p className="mt-4 text-rmigray-700 leading-7">
+              We welcome feedback, questions, and opportunities for
+              collaboration.
+            </p>
+            <p className="mt-4 text-rmigray-700 leading-7">
+              To get in touch, reach out to Tom White or Nayra Herrera at{" "}
+              <a
+                href="mailto:tomwhite+pbtar@rmi.org"
+                className="text-energy-700 underline underline-offset-2 hover:text-energy-800"
+              >
+                tomwhite@rmi.org
+              </a>{" "}
+              and{" "}
+              <a
+                href="mailto:nherrera+pbtar@rmi.org"
+                className="text-energy-700 underline underline-offset-2 hover:text-energy-800"
+              >
+                nherrera@rmi.org
+              </a>
+              , or open an issue on our{" "}
+              <a
+                href="https://github.com/RMI/pbtar/issues"
+                className="text-energy-700 underline underline-offset-2 hover:text-energy-800"
+              >
+                GitHub repository
+              </a>{" "}
+              with a short description of your request.
+            </p>
+          </div>
+
+          <div className="mt-10 border-t border-rmiblue-100 pt-8">
+            <h2 className="text-2xl font-semibold text-rmigray-800">
+              Feedback and suggestions
+            </h2>
+            <p className="mt-4 text-rmigray-700 leading-7">
+              We welcome feedback of all kinds and encourage you to share your
+              experience, questions, and ideas for improvement.
+            </p>
+            <p className="mt-4 text-rmigray-700 leading-7">
+              We are especially interested in hearing about:
+            </p>
+
+            <ul className="mt-5 list-disc space-y-3 pl-6 text-rmigray-700 marker:text-lg">
+              <li className="font-semibold leading-7">
+                Missing pathways or benchmarks
+              </li>
+              <li className="font-semibold leading-7">
+                Unclear classifications or assumptions
+              </li>
+              <li className="font-semibold leading-7">
+                Gaps in sector or regional coverage
+              </li>
+              <li className="font-semibold leading-7">Workflow pain points</li>
+              <li className="font-semibold leading-7">
+                Requests for training, guidance, or additional support
+              </li>
+            </ul>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default ContactPage;

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -48,7 +48,7 @@ const ContactPage: React.FC = () => {
               >
                 Tom White
               </a>{" "}
-               or{" "}
+              or{" "}
               <a
                 href="mailto:nherrera+pbtar@rmi.org"
                 className="text-energy-700 underline underline-offset-2 hover:text-energy-800"

--- a/src/pages/LandingPage.test.tsx
+++ b/src/pages/LandingPage.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import LandingPage from "./LandingPage";
+
+describe("LandingPage navigation", () => {
+  it("uses the shared header nav resources menu", async () => {
+    render(
+      <MemoryRouter>
+        <LandingPage />
+      </MemoryRouter>,
+    );
+
+    const user = userEvent.setup();
+
+    expect(
+      screen.getByRole("link", { name: "Contact Us" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /resources/i }));
+
+    expect(
+      screen.getByRole("menuitem", { name: "How to choose a pathway" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Use cases" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Methodology" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Updates" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "FAQs" })).toBeInTheDocument();
+  });
+});

--- a/src/pages/LandingPage.test.tsx
+++ b/src/pages/LandingPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import LandingPage from "./LandingPage";
@@ -19,19 +19,24 @@ describe("LandingPage navigation", () => {
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /resources/i }));
+    const resourcesNav = screen.getByRole("navigation", { name: "Resources" });
 
     expect(
-      screen.getByRole("menuitem", { name: "How to choose a pathway" }),
+      within(resourcesNav).getByRole("link", {
+        name: "How to choose a pathway",
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("menuitem", { name: "Use cases" }),
+      within(resourcesNav).getByRole("link", { name: "Use cases" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("menuitem", { name: "Methodology" }),
+      within(resourcesNav).getByRole("link", { name: "Methodology" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("menuitem", { name: "Updates" }),
+      within(resourcesNav).getByRole("link", { name: "Updates" }),
     ).toBeInTheDocument();
-    expect(screen.getByRole("menuitem", { name: "FAQs" })).toBeInTheDocument();
+    expect(
+      within(resourcesNav).getByRole("link", { name: "FAQs" }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 import { Link } from "react-router-dom";
+import HeaderNav from "../components/HeaderNav";
 import { HeaderBrand } from "../components/Header";
 
 const WavePattern: React.FC = () => {
@@ -135,22 +136,6 @@ const InfoCard: React.FC<{
 );
 
 const LandingPage: React.FC = () => {
-  const [resourcesOpen, setResourcesOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!resourcesOpen) return;
-    const onDocClick = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (menuRef.current && !menuRef.current.contains(target)) {
-        setResourcesOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", onDocClick);
-    return () => document.removeEventListener("mousedown", onDocClick);
-  }, [resourcesOpen]);
-
   return (
     <div className="bg-gray-50">
       {/* Hero */}
@@ -163,78 +148,7 @@ const LandingPage: React.FC = () => {
           <div className="container mx-auto px-4 pt-6">
             <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
               <HeaderBrand to="/" />
-              <nav className="mt-3 md:mt-0 flex items-center gap-2">
-                <Link
-                  to="/contact"
-                  className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-white/90 hover:text-white hover:bg-white/10 transition-colors"
-                >
-                  Contact Us
-                </Link>
-
-                <div
-                  ref={menuRef}
-                  className="relative"
-                >
-                  <button
-                    type="button"
-                    className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-white/90 hover:text-white hover:bg-white/10 transition-colors"
-                    aria-haspopup="menu"
-                    aria-expanded={resourcesOpen}
-                    onClick={() => setResourcesOpen((v) => !v)}
-                  >
-                    Resources
-                    <span className="text-white/70">▾</span>
-                  </button>
-
-                  {resourcesOpen && (
-                    <div
-                      role="menu"
-                      className="absolute right-0 z-[60] mt-2 w-72 overflow-hidden rounded-md bg-white text-rmigray-800 shadow-lg ring-1 ring-black/5"
-                    >
-                      <Link
-                        role="menuitem"
-                        to="/resources/how-to-choose-a-pathway"
-                        className="block px-4 py-3 text-sm hover:bg-neutral-100"
-                        onClick={() => setResourcesOpen(false)}
-                      >
-                        How to choose a pathway
-                      </Link>
-                      <Link
-                        role="menuitem"
-                        to="/resources/use-cases"
-                        className="block px-4 py-3 text-sm hover:bg-neutral-100"
-                        onClick={() => setResourcesOpen(false)}
-                      >
-                        Use cases
-                      </Link>
-                      <Link
-                        role="menuitem"
-                        to="/resources/methodology"
-                        className="block px-4 py-3 text-sm hover:bg-neutral-100"
-                        onClick={() => setResourcesOpen(false)}
-                      >
-                        Methodology
-                      </Link>
-                      <Link
-                        role="menuitem"
-                        to="/resources/updates"
-                        className="block px-4 py-3 text-sm hover:bg-neutral-100"
-                        onClick={() => setResourcesOpen(false)}
-                      >
-                        Updates
-                      </Link>
-                      <Link
-                        role="menuitem"
-                        to="/resources/faq"
-                        className="block px-4 py-3 text-sm hover:bg-neutral-100"
-                        onClick={() => setResourcesOpen(false)}
-                      >
-                        FAQs
-                      </Link>
-                    </div>
-                  )}
-                </div>
-              </nav>
+              <HeaderNav />
             </div>
           </div>
 

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -333,7 +333,7 @@ const LandingPage: React.FC = () => {
               sustainability, risk, and front-office teams) conducting corporate
               transition assessments. See the{" "}
               <Link
-                to="/resources/methodology"
+                to="/resources/use-cases"
                 className="text-energy-700 hover:text-energy-800 underline underline-offset-2"
               >
                 use case page

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,6 +1,5 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { TrendingUp, Lightbulb } from "lucide-react";
 import { HeaderBrand } from "../components/Header";
 
 const WavePattern: React.FC = () => {
@@ -123,102 +122,333 @@ const WavePattern: React.FC = () => {
   );
 };
 
-const Card: React.FC<{
+const InfoCard: React.FC<{
   title: string;
-  icon: React.ReactNode;
   children: React.ReactNode;
-  linkText: string;
-  linkHref: string;
-}> = ({ title, icon, children, linkText, linkHref }) => (
-  <div className="bg-white/70 backdrop-blur-sm rounded-lg shadow-md p-6 flex flex-col">
-    {" "}
-    {/* Removed mb-6 and h-full */}
-    <div className="flex items-center mb-4">
-      <span className="text-2xl mr-3">{icon}</span>
-      <h2 className="text-xl font-semibold text-rmigray-800">{title}</h2>
-    </div>
-    <div className="flex-1 text-rmigray-600 mb-4">{children}</div>
-    <a
-      href={linkHref}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="text-energy-700 font-semibold hover:underline mt-auto"
-    >
-      {linkText}
-    </a>
+}> = ({ title, children }) => (
+  <div className="rounded-lg bg-white shadow p-6">
+    <h3 className="text-sm font-semibold text-rmiblue-800 mb-3 text-center">
+      {title}
+    </h3>
+    <div className="text-sm text-rmigray-700 text-center">{children}</div>
   </div>
 );
 
 const LandingPage: React.FC = () => {
+  const [resourcesOpen, setResourcesOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!resourcesOpen) return;
+    const onDocClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (menuRef.current && !menuRef.current.contains(target)) {
+        setResourcesOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [resourcesOpen]);
+
   return (
-    <div className="min-h-screen relative overflow-hidden">
-      {/* Base gradient */}
-      <div className="absolute inset-0 bg-rmiblue-800/100"></div>{" "}
-      {/* Animated waves */}
-      <WavePattern />
-      {/* Additional gradient overlay for depth */}
-      <div className="absolute inset-0 bg-gradient-to-br from-transparent via-energy/5 to-transparent"></div>
-      {/* Content */}
-      <div className="relative min-h-screen">
-        <div className="absolute top-6 left-0 right-0">
-          <div className="container mx-auto px-4 text-white">
-            <HeaderBrand />
+    <div className="bg-gray-50">
+      {/* Hero */}
+      <div className="relative overflow-x-hidden">
+        <div className="absolute inset-0 bg-rmiblue-800/100" />
+        <WavePattern />
+        <div className="absolute inset-0 bg-gradient-to-br from-transparent via-energy/5 to-transparent" />
+
+        <div className="relative text-white">
+          <div className="container mx-auto px-4 pt-6">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <HeaderBrand to="/" />
+              <nav className="mt-3 md:mt-0 flex items-center gap-2">
+                <Link
+                  to="/contact"
+                  className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-white/90 hover:text-white hover:bg-white/10 transition-colors"
+                >
+                  Contact Us
+                </Link>
+
+                <div
+                  ref={menuRef}
+                  className="relative"
+                >
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-semibold text-white/90 hover:text-white hover:bg-white/10 transition-colors"
+                    aria-haspopup="menu"
+                    aria-expanded={resourcesOpen}
+                    onClick={() => setResourcesOpen((v) => !v)}
+                  >
+                    Resources
+                    <span className="text-white/70">▾</span>
+                  </button>
+
+                  {resourcesOpen && (
+                    <div
+                      role="menu"
+                      className="absolute right-0 z-[60] mt-2 w-72 overflow-hidden rounded-md bg-white text-rmigray-800 shadow-lg ring-1 ring-black/5"
+                    >
+                      <Link
+                        role="menuitem"
+                        to="/resources/how-to-choose-a-pathway"
+                        className="block px-4 py-3 text-sm hover:bg-neutral-100"
+                        onClick={() => setResourcesOpen(false)}
+                      >
+                        How to choose a pathway
+                      </Link>
+                      <Link
+                        role="menuitem"
+                        to="/resources/use-cases"
+                        className="block px-4 py-3 text-sm hover:bg-neutral-100"
+                        onClick={() => setResourcesOpen(false)}
+                      >
+                        Use cases
+                      </Link>
+                      <Link
+                        role="menuitem"
+                        to="/resources/methodology"
+                        className="block px-4 py-3 text-sm hover:bg-neutral-100"
+                        onClick={() => setResourcesOpen(false)}
+                      >
+                        Methodology
+                      </Link>
+                      <Link
+                        role="menuitem"
+                        to="/resources/updates"
+                        className="block px-4 py-3 text-sm hover:bg-neutral-100"
+                        onClick={() => setResourcesOpen(false)}
+                      >
+                        Updates
+                      </Link>
+                      <Link
+                        role="menuitem"
+                        to="/resources/faq"
+                        className="block px-4 py-3 text-sm hover:bg-neutral-100"
+                        onClick={() => setResourcesOpen(false)}
+                      >
+                        FAQs
+                      </Link>
+                    </div>
+                  )}
+                </div>
+              </nav>
+            </div>
+          </div>
+
+          <div className="container mx-auto px-4 py-16">
+            <div className="max-w-4xl mx-auto text-center">
+              <h1 className="text-4xl md:text-5xl font-bold tracking-tight">
+                Transition Pathways Repository
+              </h1>
+              <p className="mt-4 text-lg md:text-xl text-white/90">
+                Find and compare transition pathways to support corporate
+                transition assessments.
+              </p>
+
+              <p className="mt-8 text-sm md:text-base text-white/85 max-w-3xl mx-auto">
+                The Transition Pathways Repository helps financial institutions
+                identify and compare pathways based on their specific analytical
+                needs. Use it to identify key transition levers, benchmark
+                ambition, test transition plan feasibility, and assess policy
+                exposure.
+              </p>
+
+              <p className="mt-8 text-sm md:text-base text-white/85 max-w-3xl mx-auto">
+                Note that this version of the TPR is a pilot covering only
+                pathways related to the power sector in Southeast Asia. Stay
+                tuned for more pathways being added in 2026!
+              </p>
+
+              <div className="mt-10">
+                <Link
+                  to="/pathway"
+                  className="inline-block px-8 py-4 bg-energy-700 text-neutral-300 rounded-md hover:bg-energy-800 transition-colors duration-200 text-lg font-semibold"
+                >
+                  Explore Pathways
+                </Link>
+              </div>
+
+              <p className="mt-6 text-sm italic text-white/80">
+                See what pathways are available for the Southeast Asia power
+                sector.
+              </p>
+            </div>
           </div>
         </div>
-        <div className="container mx-auto px-4 py-12 min-h-screen flex items-center">
-          <div className="flex flex-col md:flex-row gap-10 items-stretch w-full">
-            {/* Left Column */}
-            <div className="md:w-1/2">
-              <div className="bg-white/70 backdrop-blur-sm rounded-lg p-8 shadow-md flex flex-col h-full">
-                <div className="flex-1">
-                  <h1 className="text-5xl font-bold text-rmigray-800 mb-6">
-                    Navigating the Energy Transition
-                  </h1>
-                  <p className="text-lg text-rmigray-600">
-                    Transition pathways illustrate how the energy transition
-                    will reshape sectors and systems, giving financial
-                    institutions, corporates, and other organizations greater
-                    confidence in developing, assessing, and implementing plans
-                    in a changing energy landscape.
-                  </p>
-                </div>
-                <div className="mt-auto pt-8">
+      </div>
+
+      {/* Main content */}
+      <div className="container mx-auto px-4 py-12">
+        <div className="max-w-5xl mx-auto">
+          <section className="pb-10 border-b border-neutral-200">
+            <h2 className="text-xl font-semibold text-rmiblue-800 mb-3">
+              What is the Transition Pathways Repository?
+            </h2>
+            <p className="text-rmigray-700">
+              The Transition Pathways Repository (TPR) is an online repository
+              designed to help financial institutions identify, interpret, and
+              compare the transition pathways available across sectors and
+              regions.
+            </p>
+            <p className="text-rmigray-700 mt-4">
+              The goal is to support financial institutions to better
+              incorporate the opportunities and risks created by the transition
+              into their decision-making by integrating region-specific pathways
+              into transition assessments, risk analysis, client engagement, and
+              capital allocation.
+            </p>
+          </section>
+
+          <section className="py-10 border-b border-neutral-200">
+            <h2 className="text-xl font-semibold text-rmiblue-800 mb-3">
+              Why are transition pathways important?
+            </h2>
+            <p className="text-rmigray-700">
+              Transition pathways provide the critical context needed to turn
+              data into decision-useful insights for financial institutions. As
+              corporations navigate uncertainty, transition pathways can reveal
+              how different factors could impact their business.
+            </p>
+            <p className="text-rmigray-700 mt-4">
+              Different pathways answer different questions. A pathway that is
+              useful for assessing target ambition may not be appropriate for
+              understanding regional policy or market risk.
+            </p>
+            <p className="text-rmigray-700 mt-4">
+              The TPR helps users understand those differences to ensure that
+              selected pathways are aligned with specific assessment objectives
+              and decision-making needs.
+            </p>
+          </section>
+
+          <section className="py-10 border-b border-neutral-200">
+            <h2 className="text-xl font-semibold text-rmiblue-800 mb-3">
+              Who is the TPR designed for?
+            </h2>
+            <p className="text-rmigray-700">
+              The TPR is designed primarily for financial institutions (e.g.,
+              sustainability, risk, and front-office teams) conducting corporate
+              transition assessments. See the{" "}
+              <Link
+                to="/resources/methodology"
+                className="text-energy-700 hover:text-energy-800 underline underline-offset-2"
+              >
+                use case page
+              </Link>{" "}
+              for more details.
+            </p>
+            <p className="text-rmigray-700 mt-4">
+              This tool could also be applied by corporations developing their
+              own transition strategies, and by policymakers and regulators to
+              inform policy design and regulatory frameworks.
+            </p>
+          </section>
+
+          <section className="py-10 border-b border-neutral-200">
+            <h2 className="text-xl font-semibold text-rmiblue-800 mb-6">
+              What can you do with the Transition Pathways Repository?
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <InfoCard title="Find new pathways">
+                Trying to understand your clients’ exposure to transition risk?
+                Want to understand how different policies might impact your
+                client’s transition strategy? Unsure if your client’s investment
+                pipeline matches sector trends? The TPR helps you find relevant
+                pathways for these and other use cases.
+              </InfoCard>
+              <InfoCard title="Interpret them easily">
+                These use cases are made clear by detailed analysis of each
+                pathway’s scope, underlying assumptions, and output data in a
+                standardized format for streamlined integration into existing
+                workflows.
+              </InfoCard>
+              <InfoCard title="Compare pathways">
+                Pathways have been assessed across key common variables for easy
+                comparison. Skip trawling through lengthy reports and let the
+                repository simplify the process of deciphering and comparing
+                pathways.
+              </InfoCard>
+            </div>
+          </section>
+
+          <section className="py-10">
+            <h2 className="text-xl font-semibold text-rmiblue-800 mb-3">
+              Learn more with these resources
+            </h2>
+            <div className="rounded-lg bg-white shadow p-6">
+              <ul className="list-disc pl-5 space-y-2 text-rmigray-700">
+                <li>
                   <Link
-                    to="/pathway"
-                    className="inline-block px-8 py-4 bg-energy-700 text-neutral-300 rounded-md hover:bg-energy-800 transition-colors duration-200 text-lg font-semibold"
+                    to="/resources/how-to-choose-a-pathway"
+                    className="text-energy-700 hover:text-energy-800 underline underline-offset-2"
                   >
-                    Explore Pathways
+                    How to choose a pathway
                   </Link>
-                </div>
+                </li>
+                <li>
+                  <Link
+                    to="/resources/use-cases"
+                    className="text-energy-700 hover:text-energy-800 underline underline-offset-2"
+                  >
+                    Use cases for pathways
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    to="/resources/methodology"
+                    className="text-energy-700 hover:text-energy-800 underline underline-offset-2"
+                  >
+                    How pathways are assessed and classified
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    to="/resources/updates"
+                    className="text-energy-700 hover:text-energy-800 underline underline-offset-2"
+                  >
+                    Latest updates
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    to="/resources/faq"
+                    className="text-energy-700 hover:text-energy-800 underline underline-offset-2"
+                  >
+                    FAQs
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    to="/contact"
+                    className="text-energy-700 hover:text-energy-800 underline underline-offset-2"
+                  >
+                    Get in touch
+                  </Link>
+                </li>
+              </ul>
+            </div>
+
+            <div className="mt-12 pt-10 border-t border-neutral-200 text-center">
+              <h2 className="text-2xl font-semibold text-rmigray-800">
+                Ready to explore?
+              </h2>
+              <p className="mt-3 text-rmigray-700 max-w-2xl mx-auto">
+                See what pathways are available for the Southeast Asia power
+                sector.
+              </p>
+              <div className="mt-8">
+                <Link
+                  to="/pathway"
+                  className="inline-block px-8 py-4 bg-energy-700 text-neutral-300 rounded-md hover:bg-energy-800 transition-colors duration-200 text-lg font-semibold"
+                >
+                  Explore Pathways
+                </Link>
               </div>
             </div>
-            {/* Right Column */}
-            <div className="md:w-1/2 flex flex-col gap-6">
-              <Card
-                title="Creating Transition Intelligence"
-                icon={<TrendingUp className="h-7 w-7 text-energy-700" />}
-                linkText="Learn more →"
-                linkHref="https://rmi.org/insight/creating-transition-intelligence-enhancing-corporate-transition-assessments-for-financial-decision-making"
-              >
-                Drawing on a range of transition pathways turns corporate data
-                into actionable intelligence, helping organizations test
-                strategies, manage risks, and engage stakeholders.
-              </Card>
-              <Card
-                title="RMI's Approach"
-                icon={<Lightbulb className="h-7 w-7 text-energy-700" />}
-                linkText="Learn more →"
-                linkHref="https://rmi.org/insight/leveraging-transition-pathways/"
-              >
-                This repository connects users with the right transition
-                pathways for their needs, with structured guidance for
-                navigating diverse pathway types, geographies, developers, and
-                methodologies. This repository is currently being piloted for
-                the pathways that cover the power sector in Southeast Asia, and
-                expansion to other sectors and geographies is coming soon.
-              </Card>
-            </div>
-          </div>
+          </section>
         </div>
       </div>
     </div>

--- a/src/pages/resources/ResourcesFaqPage.tsx
+++ b/src/pages/resources/ResourcesFaqPage.tsx
@@ -1,0 +1,371 @@
+import React, { useId, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+
+type FaqItem = {
+  question: string;
+  answer: React.ReactNode;
+};
+
+type FaqSection = {
+  title: string;
+  items: FaqItem[];
+};
+
+const FaqItemBlock: React.FC<FaqItem> = ({ question, answer }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const contentId = useId();
+
+  return (
+    <div className="px-6 py-5 md:px-7">
+      <h3>
+        <button
+          type="button"
+          className="group w-full text-left"
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          onClick={() => setIsOpen((value) => !value)}
+        >
+          <div className="flex items-start justify-between gap-4">
+            <span className="text-lg font-semibold text-rmigray-800 transition-colors group-hover:text-rmiblue-800">
+              {question}
+            </span>
+            <span
+              className={
+                "mt-1 text-rmigray-500 transition-transform " +
+                (isOpen ? "rotate-180" : "rotate-0")
+              }
+              aria-hidden="true"
+            >
+              ▾
+            </span>
+          </div>
+        </button>
+      </h3>
+
+      {isOpen ? (
+        <div
+          id={contentId}
+          className="mt-5 border-t border-neutral-200 pt-5 text-rmigray-700"
+        >
+          <div className="space-y-3 leading-7 [&>ul]:list-disc [&>ul]:space-y-1 [&>ul]:pl-5">
+            {answer}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+const ResourcesFaqPage: React.FC = () => {
+  const sections = useMemo<FaqSection[]>(
+    () => [
+      {
+        title: "About the TPR",
+        items: [
+          {
+            question: "What is the Transition Pathways Repository (TPR) for?",
+            answer: (
+              <>
+                <p>
+                  The TPR helps users identify which transition pathways are
+                  available and most relevant for a given use case. Different
+                  pathways can have a number of different{" "}
+                  <Link
+                    to="/resources/use-cases"
+                    className="text-energy-700 underline underline-offset-2 font-semibold hover:text-energy-800"
+                  >
+                    use cases
+                  </Link>{" "}
+                  .
+                </p>
+                <p>Users may need pathways to:</p>
+                <ul className="list-disc pl-5 space-y-1">
+                  <li>
+                    Assess the level of ambition of emissions or other
+                    sustainability targets
+                  </li>
+                  <li>Test the feasibility of targets and transition plans</li>
+                  <li>Understand policy exposure</li>
+                  <li>
+                    Identify critical decarbonization levers in a particular
+                    sector and region
+                  </li>
+                </ul>
+                <p>
+                  The TPR centralizes and standardizes this information to
+                  increase the use of transition pathways.
+                </p>
+              </>
+            ),
+          },
+          {
+            question: "Who is the TPR built for?",
+            answer: (
+              <>
+                <p>
+                  TPR is designed primarily for financial institutions using
+                  region- and sector-specific pathways in transition assessment
+                  and decision-making.
+                </p>
+                <p>It is especially relevant for:</p>
+                <ul className="list-disc pl-5 space-y-1">
+                  <li>
+                    Sustainability teams — to evaluate ambition and feasibility
+                    of corporate transition plans.
+                  </li>
+                  <li>Risk teams — to identify potential transition risks.</li>
+                  <li>
+                    Front-office and client coverage teams — to identify
+                    business development and engagement opportunities.
+                  </li>
+                  <li>
+                    Strategy teams — to develop investment theses and set
+                    capital allocation targets
+                  </li>
+                </ul>
+                <p>
+                  It can also be useful for companies, policymakers, regulators,
+                  and other users who want to better understand transition
+                  dynamics in specific sectors and regions.
+                </p>
+              </>
+            ),
+          },
+          {
+            question: "What pathways can I find in the TPR?",
+            answer: (
+              <>
+                <p>
+                  The TPR currently includes pathways related to the power
+                  sector in Southeast Asia. This includes region- and
+                  country-specific pathways, as well as global power pathways.
+                </p>
+                <p>
+                  Expansion into other sectors and regions is planned later in
+                  2026, stay tuned!
+                </p>
+              </>
+            ),
+          },
+        ],
+      },
+      {
+        title: "Using the TPR",
+        items: [
+          {
+            question: "How do I use the TPR?",
+            answer: (
+              <>
+                <p>
+                  A full description of how to make the most of the TPR can be
+                  found in our{" "}
+                  <Link
+                    to="/resources/how-to-choose-a-pathway"
+                    className="text-energy-700 underline underline-offset-2 font-semibold hover:text-energy-800"
+                  >
+                    user guide
+                  </Link>
+                  .
+                </p>
+              </>
+            ),
+          },
+          {
+            question: "Does the TPR tell me which pathway is best?",
+            answer: (
+              <>
+                <p>
+                  No. The TPR helps users compare pathways in a structured way,
+                  but it does not automatically choose one for you.
+                </p>
+                <p>
+                  The most useful pathway depends on the question you are trying
+                  to answer.
+                </p>
+              </>
+            ),
+          },
+          {
+            question: "Why can’t I use one scenario for everything?",
+            answer: (
+              <>
+                <p>Because different pathways answer different questions.</p>
+                <p>
+                  A pathway that is useful for assessing target ambition may not
+                  be the best fit for assessing policy exposure, local market
+                  conditions, or technology feasibility, as these dimensions
+                  rely on different underlying assumptions, such as current
+                  policy frameworks, infrastructure readiness, and technology
+                  maturity.
+                </p>
+              </>
+            ),
+          },
+          {
+            question:
+              "Why do some pathways have more or different benchmark data than others?",
+            answer: (
+              <>
+                <p>Not all pathway sources publish the same level of detail.</p>
+                <p>
+                  Some developers publish the high-level findings of a pathway,
+                  but not the exact benchmark data for public download. We are
+                  working to make more data available where possible.
+                </p>
+              </>
+            ),
+          },
+        ],
+      },
+      {
+        title:
+          "Using the TPR to support corporate transition assessments (CTAs)",
+        items: [
+          {
+            question: "What is a corporate transition assessment (CTA)?",
+            answer: (
+              <>
+                <p>
+                  A CTA is a structured assessment of how credible, ambitious,
+                  and feasible a company’s transition strategy appears, usually
+                  in the context of financial decision-making.
+                </p>
+                <p>
+                  See the{" "}
+                  <a
+                    href="https://rmi.org/insight/creating-transition-intelligence-enhancing-corporate-transition-assessments-for-financial-decision-making/"
+                    className="text-energy-700 underline underline-offset-2 font-semibold hover:text-energy-800"
+                  >
+                    Creating Transition Intelligence report
+                  </a>{" "}
+                  for more details on what constitutes a robust transition
+                  assessment.
+                </p>
+              </>
+            ),
+          },
+          {
+            question: "How does the TPR relate to CTAs?",
+            answer: (
+              <>
+                <p>
+                  The TPR helps users identify and interpret granular
+                  region-specific pathways that can inform benchmarks for a CTA.
+                  It does not replace a full corporate transition assessment. It
+                  supports one important part of the process: choosing and
+                  understanding suitable pathways and benchmarks.
+                </p>
+                <p>For example, users can utilize pathways to:</p>
+                <ul className="list-disc pl-5 space-y-1">
+                  <li>
+                    Benchmark the ambition of company targets given local
+                    constraints
+                  </li>
+                  <li>Assess whether transition assumptions are feasible</li>
+                  <li>Understand policy exposure</li>
+                  <li>
+                    Identify key transition technologies across sectors and
+                    geographies
+                  </li>
+                </ul>
+                <p>
+                  See the{" "}
+                  <a
+                    href="https://rmi.org/insight/leveraging-transition-pathways/"
+                    className="text-energy-700 underline underline-offset-2 font-semibold hover:text-energy-800"
+                  >
+                    Leveraging Transition Pathways report
+                  </a>
+                  .
+                </p>
+              </>
+            ),
+          },
+          {
+            question: "What else is the TPR useful for?",
+            answer: (
+              <>
+                <p>CTAs are an important use case, but not the only one.</p>
+                <p>
+                  The TPR can also support broader transition-related analysis,
+                  including informing corporate strategy, transition planning,
+                  and identification of transition bottlenecks or enablers for
+                  policymaking.
+                </p>
+              </>
+            ),
+          },
+        ],
+      },
+    ],
+    [],
+  );
+
+  return (
+    <div className="bg-gray-50">
+      <div className="container mx-auto px-4 py-8 md:py-10">
+        <section className="relative overflow-hidden rounded-[1.75rem] bg-rmiblue-800 px-6 py-8 text-white shadow-lg md:px-10 md:py-11">
+          <div className="absolute inset-0 bg-gradient-to-br from-white/8 via-transparent to-energy-700/10" />
+          <div className="absolute -right-10 top-0 h-32 w-32 rounded-full bg-white/7 blur-2xl" />
+          <div className="absolute bottom-0 left-0 h-40 w-40 rounded-full bg-energy-500/8 blur-2xl" />
+
+          <div className="relative">
+            <h1 className="text-3xl font-bold tracking-tight md:text-4xl">
+              Frequently Asked Questions
+            </h1>
+            <div className="mt-8 space-y-4 text-sm leading-7 text-white/85 md:text-base">
+              <p>
+                If you can’t find an answer to your question here, we would love
+                to hear from you. Reach out to Tom White or Jacob Kastl at{" "}
+                <a
+                  href="mailto:tomwhite+pbtar@rmi.org"
+                  className="text-white underline underline-offset-2 transition-colors hover:text-white/80"
+                >
+                  tomwhite@rmi.org
+                </a>{" "}
+                and{" "}
+                <a
+                  href="mailto:jkastl+pbtar@rmi.org"
+                  className="text-white underline underline-offset-2 transition-colors hover:text-white/80"
+                >
+                  jkastl@rmi.org
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {sections.map((section, index) => (
+          <section
+            key={section.title}
+            className={
+              "mx-auto max-w-5xl rounded-[2rem] border border-rmiblue-100 bg-rmiblue-50/60 px-6 py-8 shadow-sm md:px-8 md:py-10 " +
+              (index === 0 ? "mt-12" : "mt-14")
+            }
+          >
+            <div className="max-w-5xl">
+              <h2 className="text-2xl font-semibold text-rmigray-800">
+                {section.title}
+              </h2>
+            </div>
+
+            <div className="mt-8 max-w-5xl overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm">
+              <div className="divide-y divide-neutral-200/80">
+                {section.items.map((item) => (
+                  <FaqItemBlock
+                    key={item.question}
+                    question={item.question}
+                    answer={item.answer}
+                  />
+                ))}
+              </div>
+            </div>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ResourcesFaqPage;

--- a/src/pages/resources/ResourcesFaqPage.tsx
+++ b/src/pages/resources/ResourcesFaqPage.tsx
@@ -316,19 +316,19 @@ const ResourcesFaqPage: React.FC = () => {
             <div className="mt-8 space-y-4 text-sm leading-7 text-white/85 md:text-base">
               <p>
                 If you can’t find an answer to your question here, we would love
-                to hear from you. Reach out to Tom White or Jacob Kastl at{" "}
+                to hear from you. Reach out to{" "}
                 <a
                   href="mailto:tomwhite+pbtar@rmi.org"
                   className="text-white underline underline-offset-2 transition-colors hover:text-white/80"
                 >
-                  tomwhite@rmi.org
+                  Tom White
                 </a>{" "}
-                and{" "}
+                or{" "}
                 <a
                   href="mailto:jkastl+pbtar@rmi.org"
                   className="text-white underline underline-offset-2 transition-colors hover:text-white/80"
                 >
-                  jkastl@rmi.org
+                  Jacob Kastl
                 </a>
                 .
               </p>

--- a/src/pages/resources/ResourcesHowToChooseAPathwayPage.tsx
+++ b/src/pages/resources/ResourcesHowToChooseAPathwayPage.tsx
@@ -1,0 +1,402 @@
+import React, { useId, useState } from "react";
+import { Link } from "react-router-dom";
+
+const quickStartCards = [
+  {
+    title: "If your use case is about target ambition",
+    priorities: [
+      "Temperature outcome",
+      "Pathway type",
+      "Benchmark availability",
+    ],
+  },
+  {
+    title: "If your use case is about policy exposure",
+    priorities: [
+      "Policy-driven assumptions",
+      "Geographic scope",
+      "Benchmark data for the markets where the company operates.",
+    ],
+  },
+  {
+    title: "If your use case is about technology readiness",
+    priorities: [
+      "Technology granularity",
+      "Deployment and cost assumptions",
+      "Temporal detail",
+    ],
+  },
+  {
+    title: "If your use case is about identifying dependencies",
+    priorities: [
+      "Geographic scope",
+      "Technology detail",
+      "Technology cost assumptions",
+      "Policy assumptions",
+    ],
+  },
+];
+
+const QuickStartCard: React.FC<{
+  title: string;
+  priorities: string[];
+}> = ({ title, priorities }) => {
+  return (
+    <article className="overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm">
+      <div className="border-b border-neutral-200 bg-gradient-to-r from-rmiblue-50 via-white to-white p-5 md:p-6">
+        <h3 className="text-xl font-semibold leading-8 text-rmigray-800">
+          {title}
+        </h3>
+      </div>
+
+      <div className="p-6 md:p-7">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-rmiblue-700">
+          Prioritize
+        </p>
+        <ul className="mt-4 space-y-3 text-rmigray-700">
+          {priorities.map((priority) => (
+            <li
+              key={priority}
+              className="flex gap-3 rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-4"
+            >
+              <span className="mt-2 h-2.5 w-2.5 flex-none rounded-full bg-energy-700" />
+              <span className="leading-7">{priority}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </article>
+  );
+};
+
+const CollapsibleRow: React.FC<{
+  title: string;
+  children: React.ReactNode;
+}> = ({ title, children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const contentId = useId();
+  const [stepLabel, ...titleParts] = title.split(": ");
+  const heading = titleParts.join(": ");
+
+  return (
+    <div className="px-6 py-5 md:px-7">
+      <h3>
+        <button
+          type="button"
+          className="group w-full text-left"
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          onClick={() => setIsOpen((v) => !v)}
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-rmiblue-700">
+                {stepLabel}
+              </p>
+              <span className="mt-3 block text-xl font-semibold text-rmigray-800 transition-colors group-hover:text-rmiblue-800">
+                {heading}
+              </span>
+            </div>
+            <span
+              className={
+                "mt-1 text-rmigray-500 transition-transform " +
+                (isOpen ? "rotate-180" : "rotate-0")
+              }
+              aria-hidden="true"
+            >
+              ▾
+            </span>
+          </div>
+        </button>
+      </h3>
+
+      {isOpen ? (
+        <div
+          id={contentId}
+          className="mt-5 rounded-2xl border border-neutral-200 bg-neutral-50 p-5 text-rmigray-700 leading-7"
+        >
+          <div className="[&>ul]:list-disc [&>ul]:pl-5 [&>ul]:space-y-1 [&>p+ul]:mt-3 [&>p]:text-rmigray-700">
+            {children}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+const ResourcesHowToChooseAPathwayPage: React.FC = () => {
+  return (
+    <div className="bg-gray-50">
+      <div className="container mx-auto px-4 py-8 md:py-10">
+        <section className="relative overflow-hidden rounded-[1.75rem] bg-rmiblue-800 px-6 py-8 text-white shadow-lg md:px-10 md:py-11">
+          <div className="absolute inset-0 bg-gradient-to-br from-white/8 via-transparent to-energy-700/10" />
+          <div className="absolute -right-10 top-0 h-32 w-32 rounded-full bg-white/7 blur-2xl" />
+          <div className="absolute bottom-0 left-0 h-40 w-40 rounded-full bg-energy-500/8 blur-2xl" />
+
+          <div className="relative">
+            <h1 className="text-3xl font-bold tracking-tight md:text-4xl">
+              How to Choose a Pathway
+            </h1>
+
+            <h2 className="mt-6 text-xl font-semibold leading-8 text-white/95 md:text-2xl">
+              Five steps to identify the pathways that fit your assessment
+              question
+            </h2>
+
+            <div className="mt-8 space-y-4 text-sm leading-7 text-white/85 md:text-base">
+              <p>
+                Different energy transition pathways answer different questions.
+                A pathway that is useful for assessing company target ambition
+                may not be the best fit for assessing policy exposure or
+                technology feasibility.
+              </p>
+              <p>
+                The Transition Pathways Repository (TPR) helps you compare
+                pathways in a more structured way so you can choose the ones
+                that are most useful for your application.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-12 max-w-5xl rounded-[2rem] bg-white px-6 py-8 shadow-sm md:px-8 md:py-10">
+          <div className="max-w-5xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-rmiblue-700">
+              5-step process
+            </p>
+            <h2 className="mt-3 text-2xl font-semibold text-rmigray-800">
+              A structured way to narrow down the right pathway
+            </h2>
+            <p className="mt-4 text-rmigray-700 leading-7">
+              Selecting appropriate pathways for a transition-related question
+              follows a straightforward process, as laid out in RMI’s{" "}
+              <a
+                href="https://rmi.org/insight/leveraging-transition-pathways/"
+                className="text-energy-700 underline underline-offset-2 hover:text-energy-800"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <b>Leveraging Transition Pathways report</b>
+              </a>
+              .
+            </p>
+          </div>
+
+          <div className="mt-8 grid max-w-5xl gap-8 xl:grid-cols-[1.15fr,0.85fr]">
+            <div className="overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm">
+              <div className="border-b border-neutral-200 bg-gradient-to-r from-rmiblue-50 via-white to-white p-6 md:p-7">
+                <h3 className="text-xl font-semibold text-rmigray-800">
+                  The five-step process to selecting a pathway
+                </h3>
+              </div>
+
+              <div className="divide-y divide-neutral-200/80">
+                <CollapsibleRow title="Step 1: Define the intended application">
+                  <p>
+                    The ‘right’ pathway depends on the use case, so it is
+                    important to clarify what question you need the pathway help
+                    answer. This will then inform the decisions made in the
+                    following steps. The more specific you can be, the easier it
+                    will be to narrow down your options.
+                  </p>
+                  <p className="mt-3">Example questions could include:</p>
+                  <ul className="mt-3">
+                    <li>
+                      Are a company’s emissions targets still ambitious given
+                      local policy constraints?
+                    </li>
+                    <li>
+                      Are a company’s solar deployment targets feasible given
+                      local land-use constraints?
+                    </li>
+                    <li>
+                      Is a company on track to align with the NDC targets in the
+                      jurisdictions where they operate?
+                    </li>
+                    <li>
+                      What external constraints are preventing a company from
+                      achieving their transition goals?
+                    </li>
+                  </ul>
+                </CollapsibleRow>
+
+                <CollapsibleRow title="Step 2: Check credibility">
+                  <p>
+                    Review who produced the pathway and whether it was developed
+                    through a robust process.
+                  </p>
+                  <p className="mt-3">Useful questions include:</p>
+                  <ul className="mt-3">
+                    <li>
+                      Was it developed by an organization with strong technical
+                      expertise?
+                    </li>
+                    <li>
+                      Was it reviewed by relevant experts or stakeholders?
+                    </li>
+                    <li>Does the methodology appear technically sound?</li>
+                  </ul>
+                  <p className="mt-3">
+                    Pathways hosted on the TPR are all considered credible
+                    according to these criteria. Note that this does not mean
+                    that experts agree with the outcomes of each pathway, but
+                    that for the input assumptions made, the outputs have been
+                    appropriately modeled.
+                  </p>
+                </CollapsibleRow>
+
+                <CollapsibleRow title="Step 3: Review pathway features">
+                  <p>
+                    Look at the main characteristics of the pathway and evaluate
+                    whether they are appropriate for the question being asked.
+                  </p>
+                  <p className="mt-3">These include:</p>
+                  <ul className="mt-3">
+                    <li>Pathway type,</li>
+                    <li>Temperature outcome,</li>
+                    <li>Sector and geographic scope,</li>
+                    <li>
+                      Main drivers of change (e.g., policies or technology
+                      costs),
+                    </li>
+                    <li>
+                      Trends and outcomes (e.g., technology deployment or
+                      emissions trends).
+                    </li>
+                  </ul>
+                  <p className="mt-3">
+                    These features will help you interpret the results. See the{" "}
+                    <Link
+                      to="/resources/methodology"
+                      className="text-energy-700 underline underline-offset-2 hover:text-energy-800"
+                    >
+                      <b>Methodology section</b>
+                    </Link>{" "}
+                    for more details.
+                  </p>
+                  <p className="mt-3">
+                    You can find these features in the pathway summary and key
+                    features sections of the TPR.
+                  </p>
+                </CollapsibleRow>
+
+                <CollapsibleRow title="Step 4: Check granularity">
+                  <p>
+                    Check whether the pathway is granular enough for your
+                    application across:
+                  </p>
+                  <ul className="mt-3">
+                    <li>Geography</li>
+                    <li>Technology</li>
+                    <li>Time</li>
+                  </ul>
+                  <p className="mt-3">
+                    For example, a pathway that groups all renewables together
+                    may not be detailed enough to assess the feasibility of the
+                    rate of geothermal deployment. And a pathway that provides
+                    outputs for Southeast Asia as a whole may not be granular
+                    enough to assess policy risk in Indonesia.
+                  </p>
+                  <p className="mt-3">
+                    This information is available in the expert overview and key
+                    features of each pathway in the TPR.
+                  </p>
+                </CollapsibleRow>
+
+                <CollapsibleRow title="Step 5: Confirm benchmark data availability">
+                  <p>
+                    Finally, check whether the pathway provides the actual
+                    output data you need. A pathway may model a sector in detail
+                    but still not publish the specific benchmark metrics needed
+                    for comparison with company data.
+                  </p>
+                  <p className="mt-3">
+                    You can see what data is available in the pathway expert
+                    overview, as well as the standardized data download in the
+                    TPR.
+                  </p>
+                </CollapsibleRow>
+              </div>
+            </div>
+
+            <aside className="self-start rounded-2xl border border-energy-200 bg-neutral-100 p-7 shadow-sm">
+              <h2 className="text-xl font-semibold text-rmigray-800">
+                Credible does not mean suitable
+              </h2>
+              <div className="mt-5 space-y-4 text-rmigray-700 leading-7">
+                <p>Pathway credibility is necessary, but not sufficient.</p>
+                <p>
+                  A pathway can be robust and well developed, yet still be too
+                  broad, too generic, or missing the benchmark data needed for a
+                  given application.
+                </p>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-14 max-w-5xl rounded-[2rem] border border-rmiblue-100 bg-rmiblue-50/60 px-6 py-8 shadow-sm md:px-8 md:py-10">
+          <div className="max-w-5xl">
+            <h2 className="text-2xl font-semibold text-rmigray-800">
+              A simple way to start finding the right pathways
+            </h2>
+          </div>
+
+          <div className="mt-8 grid max-w-5xl grid-cols-1 gap-6 xl:grid-cols-2">
+            {quickStartCards.map((card) => (
+              <QuickStartCard
+                key={card.title}
+                title={card.title}
+                priorities={card.priorities}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section className="mx-auto mt-14 max-w-5xl rounded-[2rem] border border-neutral-200 bg-neutral-100/80 px-6 py-8 shadow-sm md:px-8 md:py-10">
+          <div className="max-w-5xl rounded-2xl border border-neutral-200 bg-white p-7 shadow-sm">
+            <h2 className="text-2xl font-semibold text-rmigray-800">
+              What to do next
+            </h2>
+            <ul className="mt-5 list-disc space-y-3 pl-6 text-rmigray-700 marker:text-lg">
+              <li className="font-semibold leading-7">
+                <Link
+                  to="/pathway"
+                  className="text-energy-700 underline underline-offset-2 hover:text-energy-800"
+                >
+                  Explore the available pathways
+                </Link>
+              </li>
+              <li className="font-semibold leading-7">
+                Read the{" "}
+                <Link
+                  to="/resources/methodology"
+                  className="text-energy-700 underline underline-offset-2 hover:text-energy-800"
+                >
+                  Methodology page
+                </Link>{" "}
+                for detailed definitions of pathway features and their
+                interpretation
+              </li>
+              <li className="font-semibold leading-7">
+                Read our{" "}
+                <a
+                  href="https://rmi.org/insight/leveraging-transition-pathways/"
+                  className="text-energy-700 underline underline-offset-2 hover:text-energy-800"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Leveraging Transition Pathways report
+                </a>{" "}
+                for more guidance on how financial institutions can use
+                transition pathways in their assessments
+              </li>
+            </ul>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default ResourcesHowToChooseAPathwayPage;

--- a/src/pages/resources/ResourcesMethodologyPage.tsx
+++ b/src/pages/resources/ResourcesMethodologyPage.tsx
@@ -952,7 +952,7 @@ const ResourcesMethodologyPage: React.FC = () => {
                       <p>
                         Describes the direction of unit costs of the low-carbon
                         technologies of in-scope sectors. This shows if/when
-                        newer low-carbon technologies are assumed tobecome more
+                        newer low-carbon technologies are assumed to become more
                         competitive compared to their high-carbon counterparts.
                       </p>
                     </>

--- a/src/pages/resources/ResourcesMethodologyPage.tsx
+++ b/src/pages/resources/ResourcesMethodologyPage.tsx
@@ -1,0 +1,1000 @@
+import React, { useId, useState } from "react";
+import { Link } from "react-router-dom";
+
+const DefinitionCard: React.FC<{
+  title: string;
+  children: React.ReactNode;
+}> = ({ title, children }) => {
+  return (
+    <article className="rounded-xl border border-neutral-200 bg-white p-6 shadow-sm">
+      <h3 className="text-lg font-semibold text-rmigray-800">{title}</h3>
+      <div className="mt-4 text-rmigray-700 leading-7">{children}</div>
+    </article>
+  );
+};
+
+const DetailWithValues: React.FC<{
+  description: React.ReactNode;
+  values: React.ReactNode;
+}> = ({ description, values }) => {
+  return (
+    <div className="grid gap-6 xl:grid-cols-[1.2fr,0.8fr]">
+      <div className="space-y-3 text-rmigray-700 leading-7">{description}</div>
+      <div className="rounded-xl border border-neutral-200 bg-white p-5 text-rmigray-700">
+        <div className="[&>p]:leading-7 [&>ul]:mt-3 [&>ul]:list-disc [&>ul]:space-y-1 [&>ul]:pl-5">
+          {values}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const CollapsibleSubsection: React.FC<{
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}> = ({ title, subtitle, children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const contentId = useId();
+
+  return (
+    <div className="px-6 py-5 md:px-7">
+      <h3>
+        <button
+          type="button"
+          className="group w-full text-left"
+          aria-expanded={isOpen}
+          aria-controls={contentId}
+          onClick={() => setIsOpen((v) => !v)}
+        >
+          <div className="flex items-start justify-between gap-4">
+            <span className="flex flex-col">
+              <span className="text-lg font-semibold text-rmigray-800 transition-colors group-hover:text-rmiblue-800">
+                {title}
+              </span>
+              {subtitle ? (
+                <span className="mt-2 text-sm leading-6 text-rmigray-600">
+                  {subtitle}
+                </span>
+              ) : null}
+            </span>
+            <span
+              className={
+                "mt-1 text-rmigray-500 transition-transform " +
+                (isOpen ? "rotate-180" : "rotate-0")
+              }
+              aria-hidden="true"
+            >
+              ▾
+            </span>
+          </div>
+        </button>
+      </h3>
+
+      {isOpen ? (
+        <div
+          id={contentId}
+          className="mt-5 rounded-2xl border border-neutral-200 bg-neutral-50 p-5 md:p-6"
+        >
+          {children}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+const ResourcesMethodologyPage: React.FC = () => {
+  return (
+    <div className="bg-gray-50">
+      <div className="container mx-auto px-4 py-8 md:py-10">
+        <section className="relative overflow-hidden rounded-[1.75rem] bg-rmiblue-800 px-6 py-8 text-white shadow-lg md:px-10 md:py-11">
+          <div className="absolute inset-0 bg-gradient-to-br from-white/8 via-transparent to-energy-700/10" />
+          <div className="absolute -right-10 top-0 h-32 w-32 rounded-full bg-white/7 blur-2xl" />
+          <div className="absolute bottom-0 left-0 h-40 w-40 rounded-full bg-energy-500/8 blur-2xl" />
+
+          <div className="relative">
+            <h1 className="text-3xl font-bold tracking-tight md:text-4xl">
+              Methodology
+            </h1>
+
+            <h2 className="mt-6 text-xl font-semibold leading-8 text-white/95 md:text-2xl">
+              How the Transition Pathways Repository (TPR) classifies pathways
+              and how to interpret those classifications
+            </h2>
+
+            <div className="mt-8 space-y-4 text-sm leading-7 text-white/85 md:text-base">
+              <p>
+                The TPR uses a structured classification approach to help
+                analysts compare pathways in a consistent manner. This page
+                explains the rationale behind these classifications and how they
+                can be interpreted.
+              </p>
+              <p>
+                These classifications are designed to support pathway selection
+                and interpretation for use cases such as transition assessments,
+                risk analysis, and opportunity identification. They do not
+                determine a single best pathway for a task; users must still
+                understand the underlying pathway and how it meets their needs.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-12 max-w-5xl rounded-2xl border border-energy-200 bg-neutral-100 p-7 shadow-sm">
+          <h2 className="text-2xl font-semibold text-rmigray-800">
+            Key definitions
+          </h2>
+          <p className="mt-4 text-rmigray-700 leading-7">
+            Throughout the TPR, you will see the use of closely related
+            terminology when describing pathways and their content. These are
+            the definitions used in the context of the TPR.
+          </p>
+          <p className="mt-4 text-rmigray-700 leading-7">
+            These classifications are designed to support pathway selection and
+            interpretation for use cases such as transition assessments, risk
+            analysis, and opportunity identification. They do not determine a
+            single best pathway for a task; users must still understand the
+            underlying pathway and how it meets their needs
+          </p>
+
+          <div className="mt-6 grid gap-6 xl:grid-cols-3">
+            <DefinitionCard title="Transition pathway">
+              <p>
+                A forward-looking view of how a sector, region, or economy could
+                change over time.
+              </p>
+              <p className="mt-3">
+                This covers anything from detailed models to simple policy
+                objectives.
+              </p>
+            </DefinitionCard>
+
+            <DefinitionCard title="Scenario">
+              <p>
+                A subset of pathways based on systematic modeling. Scenarios
+                often provide a structured set of assumptions.
+              </p>
+            </DefinitionCard>
+
+            <DefinitionCard title="Benchmark">
+              <p>
+                A data point from a pathway that can be compared with company
+                data. Pathways often provide multiple relevant benchmarks.
+              </p>
+            </DefinitionCard>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-14 max-w-5xl rounded-[2rem] border border-rmiblue-100 bg-rmiblue-50/60 px-6 py-8 shadow-sm md:px-8 md:py-10">
+          <div className="max-w-5xl">
+            <h2 className="text-2xl font-semibold text-rmigray-800">
+              Expert overview
+            </h2>
+            <div className="mt-6">
+              <p className="text-rmigray-700 leading-7">
+                Each pathway in the TPR has an Expert Overview that provides a
+                brief summary explaining who developed the pathway, its main
+                narrative, and its core drivers. It highlights the main
+                assumptions, key trends, and external dependencies behind the
+                transition. It helps users understand what types of assessments
+                the pathway is best suited for and where it might be less
+                suitable.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-14 max-w-5xl rounded-[2rem] border border-rmiblue-100 bg-rmiblue-50/60 px-6 py-8 shadow-sm md:px-8 md:py-10">
+          <div className="max-w-5xl">
+            <h2 className="text-2xl font-semibold text-rmigray-800">
+              Classification group 1: Pathway meta data
+            </h2>
+            <p className="mt-3 text-rmigray-700 leading-7">
+              This meta data is useful to understand the overarching idea behind
+              a pathway or scenario and the broad implications of the modeled
+              changes.
+            </p>
+          </div>
+
+          <div className="mt-8 max-w-5xl overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm">
+            <div className="divide-y divide-neutral-200/80">
+              <CollapsibleSubsection
+                title="Pathway type"
+                subtitle="Is the pathway predictive, exploratory, or normative?"
+              >
+                <div className="grid grid-cols-1 gap-6 text-rmigray-700 md:grid-cols-2">
+                  <div className="rounded-xl border border-neutral-200 bg-white p-5">
+                    <h4 className="text-base font-semibold text-rmigray-800">
+                      Predictive
+                    </h4>
+                    <p className="mt-3 leading-7">
+                      All outcomes are modeled based on existing trends without
+                      any additional assumptions. No new policies are introduced
+                      or changed. No major technological breakthroughs are
+                      achieved.
+                    </p>
+                    <p className="mt-3 leading-7">
+                      These pathways often describe business-as-usual
+                      trajectories and can be useful as baseline benchmarks,
+                      especially in risk applications.
+                    </p>
+                  </div>
+
+                  <div className="rounded-xl border border-neutral-200 bg-white p-5">
+                    <h4 className="text-base font-semibold text-rmigray-800">
+                      Exploratory
+                    </h4>
+                    <p className="mt-3 leading-7">
+                      Exploratory pathways test the impact of different
+                      assumptions that are plausible but not necessarily
+                      predicted. They will differ from a mere continuation of
+                      existing trends in policies, technology costs, or demand.
+                    </p>
+                    <p className="mt-3 leading-7">
+                      These are often useful for assessing risks and
+                      opportunities under alternative policy, market, or
+                      technology conditions. Typical cases are pathways that
+                      consider announced policies, such as NDCs.
+                    </p>
+                  </div>
+
+                  <div className="rounded-xl border border-neutral-200 bg-white p-5 md:col-span-2">
+                    <h4 className="text-base font-semibold text-rmigray-800">
+                      Normative
+                    </h4>
+                    <p className="mt-3 leading-7">
+                      Normative pathways begin with a target end state, often a
+                      climate outcome such as 1.5°C, and work backward to
+                      produce a pathway consistent with that goal. They often
+                      use optimization models.
+                    </p>
+                    <p className="mt-3 leading-7">
+                      These pathways are often useful for questions of ambition.
+                    </p>
+                  </div>
+                </div>
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="Temperature outcome"
+                subtitle="What is the temperature rise by the end of the century?"
+              >
+                <div className="space-y-3 text-rmigray-700 leading-7">
+                  <p>
+                    Where available, the temperature outcome of a pathway can be
+                    used as a proxy for pathway ambition. It refers to the
+                    global average temperature rise above pre-industrial levels
+                    by the end of the century.
+                  </p>
+                  <p>
+                    Global pathways often provide a temperature outcome as they
+                    can be linked to a carbon budget. Region- or sector-specific
+                    pathways usually do not have a clear temperature outcome
+                    because a global economy-wide model is required to calculate
+                    it.
+                  </p>
+                </div>
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="Start year of model"
+                subtitle="What is the first year modeled?"
+              >
+                <div className="text-rmigray-700 leading-7">
+                  <p>
+                    The start year of the model refers to the last year before
+                    any forward-looking modeling. It is the final year of the
+                    historical baseline used in the calculations of the pathway.
+                  </p>
+                </div>
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="End year of model"
+                subtitle="What is the last year modeled?"
+              >
+                <div className="space-y-3 text-rmigray-700 leading-7">
+                  <p>
+                    The end year of the model refers to the final year of the
+                    forward-looking output generated by the model, focusing on
+                    the available pathway metrics as a reference.
+                  </p>
+                  <p>
+                    For example, if the pathway metrics are available until
+                    2050, but there is a temperature outcome for 2100, then the
+                    end year is 2050.
+                  </p>
+                </div>
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="Net zero reached"
+                subtitle="When does the pathway reach net-zero emissions?"
+              >
+                <div className="space-y-3 text-rmigray-700 leading-7">
+                  <p>
+                    The year in which the pathway reaches net-zero emissions.
+                    Not all pathways reach net-zero emissions, so this value
+                    will not always be provided.
+                  </p>
+                  <p>
+                    In some cases, net zero will refer to a specific region or
+                    (set of) sector(s). Where this is the case, the scope is
+                    indicated accordingly.
+                  </p>
+                </div>
+              </CollapsibleSubsection>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-14 max-w-5xl rounded-[2rem] border border-rmiblue-100 bg-rmiblue-50/60 px-6 py-8 shadow-sm md:px-8 md:py-10">
+          <div className="max-w-5xl">
+            <h2 className="text-2xl font-semibold text-rmigray-800">
+              Classification group 2: Scope, Granularity, Availability
+            </h2>
+            <p className="mt-3 text-rmigray-700 leading-7">
+              In transition assessments, company metrics are compared with
+              benchmarks from pathways. To ensure this is a fair comparison, it
+              is important that the scope, granularity, and data availability of
+              the benchmark data in the pathway matches those of the company (or
+              that any deviations can be approximated transparently).
+            </p>
+          </div>
+
+          <div className="mt-8 max-w-5xl overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm">
+            <div className="divide-y divide-neutral-200/80">
+              <CollapsibleSubsection
+                title="Regions"
+                subtitle="Which regions and countries are covered?"
+              >
+                <div className="space-y-3 text-rmigray-700 leading-7">
+                  <p>
+                    The list of regions and countries covered by the pathway.
+                    This will only list countries or regions that the pathway
+                    provides benchmark metrics for. All individual countries are
+                    allowed, based on ISO2 (3166) definitions. Regions are
+                    provided as defined in the pathway.
+                  </p>
+                  <p>
+                    <i>
+                      Note: RMI does not make any statements on country
+                      delineations and/or conflicting territorial claims.
+                    </i>
+                  </p>
+                </div>
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="Sectors"
+                subtitle="Which sectors are covered?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        List of sectors that the pathway covers, where coverage
+                        means that the pathway provides at least one relevant
+                        output metric for each of the sectors assigned here.
+                      </p>
+                      <p>
+                        The repository is currently limited to providing
+                        detailed information on the power sector. Additional
+                        sectors will be added in the near future. This variable
+                        also clarifies which other sectors a pathway models.
+                      </p>
+                    </>
+                  }
+                  values={
+                    <>
+                      <p>The list of allowed values is:</p>
+                      <ul>
+                        <li>Power</li>
+                      </ul>
+                    </>
+                  }
+                />
+              </CollapsibleSubsection>
+
+              {/* <CollapsibleSubsection
+                title="Sector segments"
+                subtitle="Which parts of the sector supply chain are covered?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        List of segments of sectors that the pathway covers.
+                        Segments are the main individual parts of the sector’s
+                        value chain and/or market segments. The sector segments
+                        listed for a pathway are the segments used in modeling
+                        the pathway results. Sector-specific metrics
+                        additionally clarify the segments they cover, which may
+                        be a subset of the sector segments used in the model.
+                      </p>
+                      <p>
+                        For example, a pathway may describe which input fuels
+                        are used in the power sector and as such it covers
+                        “upstream input fuels and materials.” However, for the
+                        “emissions intensity” benchmark metric, it will only
+                        cover the “power generation (on-grid)” segment of the
+                        sector.
+                      </p>
+                    </>
+                  }
+                  values={
+                    <>
+                      <p>
+                        Sector segments are only defined for the sectors that
+                        are covered in detail, and the allowed values are listed
+                        below.
+                      </p>
+                      <ul>
+                        <li>
+                          Power: Upstream input fuels and materials, power
+                          generation (on-grid), captive power generation
+                          (behind-the-meter), power storage, power grid
+                          (transmission and distribution, grid connection)
+                        </li>
+                        <li>
+                          Aviation: Fuel production, fuel system logistics,
+                          fleet transition, fleet operation (passenger), fleet
+                          operation (freight), airport and airspace system
+                        </li>
+                        <li>
+                          Steel: Iron mining, fuel procurement, iron reduction,
+                          steelmaking and casting, steel product shaping,
+                          finished product manufacturing
+                        </li>
+                      </ul>
+                    </>
+                  }
+                />
+              </CollapsibleSubsection> */}
+
+              <CollapsibleSubsection
+                title="Technologies"
+                subtitle="What is the technological granularity?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        This field shows the technologies that a pathway
+                        provides output for within the sector(s) that it covers.
+                        It is returned for any sector that is identified as
+                        in-scope in the “sectors” variable and that has
+                        specified allowed values here. As the sector coverage of
+                        the TPR expands, sectors that we show technologies for
+                        will also expand.
+                      </p>
+                    </>
+                  }
+                  values={
+                    <ul>
+                      <li>
+                        Power: Coal, oil, gas, nuclear, hydro, wind, solar,
+                        biomass, renewables, other
+                      </li>
+                      {/* <li>
+                        Steel: BOF, DRI-BOF, BF-BOF, EAF, DRI-EAF, scrap-EAF,
+                        electrolyzer/electrowinning, other
+                      </li>
+                      <li>
+                        Aviation: JET A, SAF, electricity (for
+                        battery-electric aircraft), hydrogen (for hydrogen
+                        aircraft), HEFA (biofuels, including FT with biomass),
+                        PtL (incl. G/FT), AtJ, other
+                      </li> */}
+                    </ul>
+                  }
+                />
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="Metrics"
+                subtitle="What sector-specific metrics are provided?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        List of sector-specific benchmark metrics that the
+                        pathway reports outcomes for. Currently, this is only
+                        defined for the power sector, but it will be expanded to
+                        each additional sector that we fully cover in the
+                        repository.
+                      </p>
+                    </>
+                  }
+                  values={
+                    <ul>
+                      <li>
+                        Power: Emissions intensity, Absolute emissions,
+                        Capacity, Generation, Technology mix.
+                      </li>
+                      {/* <li>
+                        Aviation: Emissions intensity (passenger), Emissions
+                        intensity (freight), Absolute emissions well-to-wheel
+                        (passenger), Absolute emissions well-to-wheel
+                        (freight), Total demand (passenger), Total demand
+                        (freight), Demand by propulsion technology
+                        (passenger), Demand by propulsion technology
+                        (freight), Demand share by propulsion technology
+                        (passenger), Demand share by propulsion technology
+                        (freight),
+                      </li>
+                      <li>
+                        Steel: Emissions intensity (total), Emissions intensity
+                        (primary), Emissions intensity (secondary), Absolute
+                        emissions, Emissions intensity by production route,
+                        Technology mix (production by route), Steel production
+                        by technology (production route), Scrap share.
+                      </li> */}
+                    </ul>
+                  }
+                />
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="Emissions scope"
+                subtitle="Which GHGs are modeled?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        Describes which GHGs are considered in scope in the
+                        pathway’s emissions results. This means that this refers
+                        to absolute emissions and emissions intensity metrics.
+                      </p>
+                      <p>
+                        Where the scope of GHGs covered differs from the entity
+                        the benchmark data is supposed to be compared to (e.g.,
+                        the emissions reported by a company), the analyst may
+                        have to consider making additional calculations or
+                        assumptions to be able to use the pathway, or use
+                        another pathway that matches the emissions scope.
+                      </p>
+                    </>
+                  }
+                  values={
+                    <>
+                      <p>The list of allowed values is:</p>
+                      <ul>
+                        <li>CO2</li>
+                        <li>CO2e (Kyoto)</li>
+                        <li>CO2e (CO2, methane)</li>
+                        <li>CO2e (unspecified GHGs)</li>
+                        <li>Other emissions scope</li>
+                        <li>No information</li>
+                      </ul>
+                    </>
+                  }
+                />
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="Policy types"
+                subtitle="Which policy types are modeled?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        Lists which types of policies the pathway models. This
+                        only refers to the policy instrument, not its level of
+                        ambition.
+                      </p>
+                      <p>
+                        This information is particularly relevant when analyzing
+                        the potential impacts of a company’s exposure to
+                        policies in the region they operate in.
+                      </p>
+                    </>
+                  }
+                  values={
+                    <>
+                      <p>The list of allowed values is:</p>
+                      <ul>
+                        <li>Carbon price</li>
+                        <li>Phaseout dates</li>
+                        <li>Subsidies</li>
+                        <li>Target technology shares</li>
+                        <li>Feed-in tariffs</li>
+                        <li>Performance standards</li>
+                        <li>Other</li>
+                      </ul>
+                    </>
+                  }
+                />
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="New technologies included"
+                subtitle="Which new technologies play a role?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        A list of the main new technologies covered by the
+                        pathway that are not necessarily deployed at scale yet
+                        but that will play a role in the future.
+                      </p>
+                      <p>
+                        Analysts can use this as a proxy for how optimistic the
+                        pathway is regarding technological breakthroughs. This
+                        can be useful both as a first step in technology risk
+                        analysis as well as in opportunity identification.
+                      </p>
+                    </>
+                  }
+                  values={
+                    <>
+                      <p>The list of allowed values is:</p>
+                      <ul>
+                        <li>No new technologies</li>
+                        <li>CCUS</li>
+                        <li>DAC</li>
+                        <li>Green H2/ammonia</li>
+                        <li>SAF</li>
+                        <li>Battery storage</li>
+                        <li>EGS/AGS</li>
+                        <li>Other new technologies</li>
+                        <li>No information</li>
+                      </ul>
+                    </>
+                  }
+                />
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="Technology costs detail"
+                subtitle="How are technology unit costs broken down?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        Describes the level of granularity that is available for
+                        technology unit cost data.
+                      </p>
+                      <p>
+                        A more granular breakdown can be useful when a company’s
+                        future profitability and competitiveness is to be
+                        analyzed, especially in technologies whose costs are
+                        projected to decrease over time.
+                      </p>
+                    </>
+                  }
+                  values={
+                    <>
+                      <p>The list of allowed values is:</p>
+                      <ul>
+                        <li>Total costs</li>
+                        <li>Capital costs, O&amp;M, etc.</li>
+                        <li>Other cost breakdown</li>
+                        <li>No information</li>
+                      </ul>
+                    </>
+                  }
+                />
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="Investment needs"
+                subtitle="In what level of detail are investment needs described?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        Describes the availability and granularity of the
+                        investment needs data provided by the pathway.
+                      </p>
+                      <p>
+                        This can indicate if the investment pipeline of a
+                        company is on pace with assumed requirements of the
+                        pathway. Where more detail is provided, it can also
+                        highlight what part of the value chain needs most
+                        investment and if that is reflected in a company’s
+                        strategy.
+                      </p>
+                    </>
+                  }
+                  values={
+                    <>
+                      <p>The list of allowed values is:</p>
+                      <ul>
+                        <li>Total investment</li>
+                        <li>By sector</li>
+                        <li>By sector and value chain segment</li>
+                        <li>By technology</li>
+                        <li>By technology and value chain segment</li>
+                        <li>No information</li>
+                      </ul>
+                    </>
+                  }
+                />
+              </CollapsibleSubsection>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-14 max-w-5xl rounded-[2rem] border border-rmiblue-100 bg-rmiblue-50/60 px-6 py-8 shadow-sm md:px-8 md:py-10">
+          <div className="max-w-5xl">
+            <h2 className="text-2xl font-semibold text-rmigray-800">
+              Classification group 3: Trends, Assumptions, Narrative
+            </h2>
+            <p className="mt-3 text-rmigray-700 leading-7">
+              Each pathway describes trends that are built on assumptions of how
+              the future will unfold. Together, these paint a picture of the
+              pathway narrative. Different types of corporate transition
+              assessment use cases usually work with different types of
+              narratives, which is why it is crucial to have a good grasp of the
+              pathway’s assumptions and trends when selecting pathways for an
+              analysis.
+            </p>
+          </div>
+
+          <div className="mt-8 max-w-5xl overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm">
+            <div className="divide-y divide-neutral-200/80">
+              <CollapsibleSubsection
+                title="Emissions trajectory"
+                subtitle="What is the direction of the GHG emissions trend?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        Summarizes how GHG emissions change in the pathway
+                        between the start year of the model and the end year of
+                        the model.
+                      </p>
+                      <p>
+                        The underlying calculation is made using the compound
+                        annual growth rate.
+                      </p>
+                      {/* <p>
+                        Comes with an indication of regional and sectoral
+                        scope.
+                      </p> */}
+                    </>
+                  }
+                  values={
+                    <>
+                      <p>The list of allowed values is:</p>
+                      <ul>
+                        <li>Significant increase</li>
+                        <li>Moderate increase</li>
+                        <li>Minor increase</li>
+                        <li>Low or no change</li>
+                        <li>Minor decrease</li>
+                        <li>Moderate decrease</li>
+                        <li>Significant decrease</li>
+                        <li>No information</li>
+                      </ul>
+                    </>
+                  }
+                />
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="Energy efficiency"
+                subtitle="What is the direction of the energy efficiency trend?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        Summarizes how energy efficiency, defined as energy use
+                        per USD GDP output, changes in the pathway between the
+                        start year of the model and the end year of the model.
+                      </p>
+                      <p>
+                        The underlying calculation is made using the compound
+                        annual growth rate.
+                      </p>
+                      {/* <p>
+                        Comes with an indication of regional and sectoral
+                        scope.
+                      </p> */}
+                    </>
+                  }
+                  values={
+                    <>
+                      <p>The list of allowed values is:</p>
+                      <ul>
+                        <li>Significant deterioration</li>
+                        <li>Moderate deterioration</li>
+                        <li>Minor deterioration</li>
+                        <li>Low or no change</li>
+                        <li>Minor improvement</li>
+                        <li>Moderate improvement</li>
+                        <li>Significant improvement</li>
+                        <li>No information</li>
+                      </ul>
+                    </>
+                  }
+                />
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="Energy demand"
+                subtitle="What is the direction of the energy demand trend?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        Summarizes how energy demand changes in the pathway
+                        between the start year of the model and the end year of
+                        the model.
+                      </p>
+                      <p>
+                        The underlying calculation is made using the compound
+                        annual growth rate.
+                      </p>
+                      {/* <p>
+                        Comes with an indication of regional and sectoral
+                        scope.
+                      </p> */}
+                    </>
+                  }
+                  values={
+                    <>
+                      <p>The list of allowed values is:</p>
+                      <ul>
+                        <li>Significant increase</li>
+                        <li>Moderate increase</li>
+                        <li>Minor increase</li>
+                        <li>Low or no change</li>
+                        <li>Minor decrease</li>
+                        <li>Moderate decrease</li>
+                        <li>Significant decrease</li>
+                        <li>No information</li>
+                      </ul>
+                    </>
+                  }
+                />
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="Electrification"
+                subtitle="What is the direction of the electrification trend?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        Summarizes how the share of electricity in energy end
+                        use changes in the pathway between the start year of the
+                        model and the end year of the model.
+                      </p>
+                      <p>
+                        The underlying calculation is made using the compound
+                        annual growth rate.
+                      </p>
+                      {/* <p>
+                        Comes with an indication of regional and sectoral
+                        scope.
+                      </p> */}
+                    </>
+                  }
+                  values={
+                    <>
+                      <p>The list of allowed values is:</p>
+                      <ul>
+                        <li>Significant increase</li>
+                        <li>Moderate increase</li>
+                        <li>Minor increase</li>
+                        <li>Low or no change</li>
+                        <li>Minor decrease</li>
+                        <li>Moderate decrease</li>
+                        <li>Significant decrease</li>
+                        <li>No information</li>
+                      </ul>
+                    </>
+                  }
+                />
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="Policy ambition"
+                subtitle="How ambitious are transition-related policies?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        Describes the level of ambition of the policies modelled
+                        in the pathway. This is a key differentiator for many
+                        pathways.
+                      </p>
+                      <p>
+                        From a risk angle, ambition closer to
+                        “current/legislated” is more likely to occur, but not
+                        the only plausible future outcome. Higher ambition
+                        pathways often come with remaining implementation gaps,
+                        which means they can be a good basis to understand
+                        bottlenecks for the transition of a sector. These, in
+                        turn, can be opportunities in some cases, or indicators
+                        of where to intervene.
+                      </p>
+                    </>
+                  }
+                  values={
+                    <>
+                      <p>The list of allowed values is:</p>
+                      <ul>
+                        <li>No policies included</li>
+                        <li>Current/legislated policies</li>
+                        <li>Current and drafted policies</li>
+                        <li>NDCs, unconditional only</li>
+                        <li>NDCs including conditional targets</li>
+                        <li>High-ambition policies</li>
+                        <li>Other policy ambition</li>
+                        <li>No information</li>
+                      </ul>
+                    </>
+                  }
+                />
+              </CollapsibleSubsection>
+
+              <CollapsibleSubsection
+                title="Technology cost trend"
+                subtitle="What is the cost trend for low-carbon technologies?"
+              >
+                <DetailWithValues
+                  description={
+                    <>
+                      <p>
+                        Describes the direction of unit costs of the low-carbon
+                        technologies of in-scope sectors. This shows if/when
+                        newer low-carbon technologies are assumed tobecome more
+                        competitive compared to their high-carbon counterparts.
+                      </p>
+                    </>
+                  }
+                  values={
+                    <>
+                      <p>The list of allowed values is:</p>
+                      <ul>
+                        <li>Increase</li>
+                        <li>Low or no change</li>
+                        <li>Decrease</li>
+                        <li>No information</li>
+                      </ul>
+                    </>
+                  }
+                />
+              </CollapsibleSubsection>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-14 max-w-5xl rounded-[2rem] border border-neutral-200 bg-neutral-100/80 px-6 py-8 shadow-sm md:px-8 md:py-10">
+          <div className="max-w-5xl rounded-2xl border border-neutral-200 bg-white p-7 shadow-sm">
+            <h2 className="text-2xl font-semibold text-rmigray-800">
+              Looking for practical guidance?
+            </h2>
+            <p className="mt-4 text-rmigray-700 leading-7">
+              Visit the{" "}
+              <Link
+                to="/resources/how-to-choose-a-pathway"
+                className="text-energy-700 underline underline-offset-2 font-semibold hover:text-energy-800"
+              >
+                How to Choose a Pathway page
+              </Link>{" "}
+              for a simpler, step-by-step guide to applying these
+              classifications in the TPR.
+            </p>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default ResourcesMethodologyPage;

--- a/src/pages/resources/ResourcesMethodologyPage.tsx
+++ b/src/pages/resources/ResourcesMethodologyPage.tsx
@@ -129,13 +129,6 @@ const ResourcesMethodologyPage: React.FC = () => {
             terminology when describing pathways and their content. These are
             the definitions used in the context of the TPR.
           </p>
-          <p className="mt-4 text-rmigray-700 leading-7">
-            These classifications are designed to support pathway selection and
-            interpretation for use cases such as transition assessments, risk
-            analysis, and opportunity identification. They do not determine a
-            single best pathway for a task; users must still understand the
-            underlying pathway and how it meets their needs
-          </p>
 
           <div className="mt-6 grid gap-6 xl:grid-cols-3">
             <DefinitionCard title="Transition pathway">

--- a/src/pages/resources/ResourcesUpdatesPage.tsx
+++ b/src/pages/resources/ResourcesUpdatesPage.tsx
@@ -1,0 +1,311 @@
+import React from "react";
+
+type UpdateTag = "Coverage" | "Functionality" | "Methodology" | "Insights";
+
+type UpdatePost = {
+  title: string;
+  date: string;
+  tags: UpdateTag[];
+  body: React.ReactNode;
+};
+
+/* const categories: Array<{
+  tag: UpdateTag;
+  description: string;
+}> = [
+  {
+    tag: "Coverage",
+    description:
+      "Information on which pathways, sectors, and regions you can find in the TPR.",
+  },
+  {
+    tag: "Functionality",
+    description: "Improvements of the features and tools available in the TPR.",
+  },
+  {
+    tag: "Methodology",
+    description:
+      "Information on how pathways are assessed and presented in the TPR.",
+  },
+  {
+    tag: "Insights",
+    description:
+      "Updates, case studies, and stories highlighting how the TPR can be leveraged in real life analyses.",
+  },
+]; */
+
+const tagClassNames: Record<UpdateTag, string> = {
+  Coverage: "border border-sky-200 bg-sky-50 text-sky-800",
+  Functionality: "border border-amber-200 bg-amber-50 text-amber-800",
+  Methodology: "border border-violet-200 bg-violet-50 text-violet-800",
+  Insights: "border border-emerald-200 bg-emerald-50 text-emerald-800",
+};
+
+const posts: UpdatePost[] = [
+  // Add new posts at the top so the latest update appears first.
+  // Example:
+  // {
+  //   title: "Power sector coverage expanded for Southeast Asia",
+  //   date: "May 7, 2026",
+  //   tags: ["Coverage", "Insights"],
+  //   body: (
+  //     <>
+  //       <p>
+  //         We added new pathway coverage for additional Southeast Asian
+  //         markets and refreshed several pathway summaries.
+  //       </p>
+  //       <p>
+  //         This update makes it easier to compare regional and country-level
+  //         pathways for transition assessments.
+  //       </p>
+  //     </>
+  //   ),
+  // },
+  {
+    title:
+      "Four lessons learned from evaluating the transition pathway landscape in the Southeast Asia power sector",
+    date: "May 15, 2026",
+    tags: ["Insights"],
+    body: (
+      <>
+        <p>
+          RMI’s Transition Pathway Repository was developed to make transition
+          pathways easier to find and use, starting with the Southeast Asia
+          power sector. The development process revealed where decision-useful
+          pathways data already exists, but also where key gaps still limit how
+          these pathways can be effectively used in transition assessments.
+        </p>
+        <p>Four key lessons learned from this process were:</p>
+        <ol className="list-decimal space-y-4 pl-5">
+          <li>
+            <p>
+              <b>
+                The power pathway landscape in emerging markets is richer than
+                expected
+              </b>
+            </p>
+            <p>
+              RMI’s systematic review of the pathways available in Southeast
+              Asia revealed almost 60 pathways currently available on the
+              Repository from 17 different publications and 11 different
+              institutions.
+            </p>
+          </li>
+          <li>
+            <p>
+              <b>
+                Pathway developers output consistent and granular data points
+                for most power sector indicators
+              </b>
+            </p>
+            <p>
+              Transition assessment methodologies show a high degree of
+              convergence around a core set of power-sector indicators,
+              including absolute emissions, installed capacity mix, generation
+              mix, and emissions intensity.
+            </p>
+          </li>
+          <li>
+            <p>
+              <b>Access to underlying pathway data is still limited</b>
+            </p>
+            <p>
+              Underlying data for these pathways is often confined to high-level
+              reports and not readily available publicly.
+            </p>
+          </li>
+          <li>
+            <p>
+              <b>
+                By focusing on generation, transition pathways can miss other
+                dependencies
+              </b>
+            </p>
+            <p>
+              Assumptions or modeling related to grid infrastructure, demand
+              flexibility, interconnection, and investment needs are frequently
+              simplified, lack granularity, or are absent.
+            </p>
+          </li>
+        </ol>
+
+        <p>
+          <b>
+            Read the{" "}
+            <a
+              href="https://rmi.org/improving-energy-transition-assessments-with-regional-pathways/"
+              className="text-energy-700 underline underline-offset-2 hover:text-energy-800"
+            >
+              full article
+            </a>{" "}
+            for a complete explanation of these lessons.
+          </b>
+        </p>
+      </>
+    ),
+  },
+  {
+    title:
+      "Introducing the Transition Pathways Repository: Making Transition Analysis Actionable",
+    date: "December 11, 2025",
+    tags: ["Functionality", "Coverage"],
+    body: (
+      <>
+        <p>
+          On December 11, 2025, RMI’s Climate Finance team launched the pilot
+          version of the Transition Pathways Repository (TPR), an online tool
+          designed to bring clarity and efficiency to corporate transition
+          analysis by making more than 50 transition pathways accessible in a
+          single place.
+        </p>
+        <p>
+          During the launch webinar, we explored the evolving landscape of
+          corporate transition analyses and discussed how transition plan
+          assessments can inform decision-making within financial institutions,
+          strengthening metrics used across sustainability, risk, strategy, and
+          front office functions.
+        </p>
+        <p>
+          To deliver real value, transition plan credibility assessments must go
+          beyond high-level narratives. They need to be granular,
+          forward-looking, and generate metrics that are decision-useful for
+          existing risk and front office workflows. These metrics often require
+          transition pathways to put them into context but finding the right
+          transition pathway to provide that context can be time-consuming and
+          resource intensive.{" "}
+          <b>
+            The TPR helps financial institutions navigate the vast field of
+            transition pathways, making it easier and faster to identify
+            relevant benchmarks for assessing how effectively companies are
+            navigating the transition.
+          </b>
+        </p>
+        <p>
+          Watch the{" "}
+          <a
+            href="https://www.youtube.com/watch?v=Xq730bspPh4"
+            className="text-energy-700 underline underline-offset-2 hover:text-energy-800"
+          >
+            <b>recording of our launch webinar</b>
+          </a>
+          .
+        </p>
+        <p>
+          The pilot version of this tool focuses on the power sector in
+          Southeast Asia, offering a first look at the platform’s capabilities.
+          But stay tuned for updates on new features and expanded regional and
+          sectoral coverage in 2026.
+        </p>
+      </>
+    ),
+  },
+];
+
+const ResourcesUpdatesPage: React.FC = () => {
+  return (
+    <div className="bg-gray-50">
+      <div className="container mx-auto px-4 py-8 md:py-10">
+        <section className="relative overflow-hidden rounded-[1.75rem] bg-rmiblue-800 px-6 py-8 text-white shadow-lg md:px-10 md:py-11">
+          <div className="absolute inset-0 bg-gradient-to-br from-white/8 via-transparent to-energy-700/10" />
+          <div className="absolute -right-10 top-0 h-32 w-32 rounded-full bg-white/7 blur-2xl" />
+          <div className="absolute bottom-0 left-0 h-40 w-40 rounded-full bg-energy-500/8 blur-2xl" />
+
+          <div className="relative">
+            <h1 className="text-3xl font-bold tracking-tight md:text-4xl">
+              Updates
+            </h1>
+
+            <p className="mt-6 text-xl font-semibold leading-8 text-white/95 md:text-2xl">
+              Check out the latest from our team on the Transition Pathways
+              Repository (TPR) and its use cases.
+            </p>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-12 max-w-5xl">
+          {/* <div className="max-w-5xl">
+            <h2 className="text-2xl font-semibold text-rmigray-800">
+              Categories
+            </h2>
+          </div>
+
+          <div className="mt-8 grid max-w-5xl gap-3 md:grid-cols-2">
+            {categories.map((category) => (
+              <div
+                key={category.tag}
+                className="rounded-2xl border border-neutral-200 bg-neutral-100/80 p-4 shadow-sm"
+              >
+                <span
+                  className={
+                    "inline-flex rounded-full px-3 py-1 text-xs font-semibold " +
+                    tagClassNames[category.tag]
+                  }
+                >
+                  {category.tag}
+                </span>
+                <p className="mt-3 text-sm leading-7 text-rmigray-700">
+                  {category.description}
+                </p>
+              </div>
+            ))}
+          </div> */}
+
+          <div className="max-w-5xl">
+            <h2 className="text-2xl font-semibold text-rmigray-800 mt-8">
+              Latest updates
+            </h2>
+          </div>
+
+          {posts.length > 0 ? (
+            <div className="mt-8 max-w-5xl space-y-6">
+              {posts.map((post) => (
+                <article
+                  key={`${post.date}-${post.title}`}
+                  className="rounded-2xl border border-neutral-200 bg-white p-7 shadow-sm"
+                >
+                  <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
+                    <div className="min-w-0">
+                      <h3 className="text-2xl font-semibold text-rmigray-800">
+                        {post.title}
+                      </h3>
+                      <p className="mt-2 text-sm font-medium text-rmigray-500">
+                        {post.date}
+                      </p>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2 md:justify-end">
+                      {post.tags.map((tag) => (
+                        <span
+                          key={`${post.title}-${tag}`}
+                          className={
+                            "rounded-full px-3 py-1 text-sm font-semibold " +
+                            tagClassNames[tag]
+                          }
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="mt-6 space-y-4 text-rmigray-700 leading-7">
+                    {post.body}
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div className="mt-8 max-w-5xl rounded-2xl border border-neutral-200 bg-white p-7 shadow-sm">
+              <p className="text-rmigray-700 leading-7">
+                No posts have been added yet. When you are ready, add a new
+                entry to the `posts` array at the top of this file.
+              </p>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default ResourcesUpdatesPage;

--- a/src/pages/resources/ResourcesUpdatesPage.tsx
+++ b/src/pages/resources/ResourcesUpdatesPage.tsx
@@ -1,44 +1,9 @@
 import React from "react";
 
-type UpdateTag = "Coverage" | "Functionality" | "Methodology" | "Insights";
-
 type UpdatePost = {
   title: string;
   date: string;
-  tags: UpdateTag[];
   body: React.ReactNode;
-};
-
-/* const categories: Array<{
-  tag: UpdateTag;
-  description: string;
-}> = [
-  {
-    tag: "Coverage",
-    description:
-      "Information on which pathways, sectors, and regions you can find in the TPR.",
-  },
-  {
-    tag: "Functionality",
-    description: "Improvements of the features and tools available in the TPR.",
-  },
-  {
-    tag: "Methodology",
-    description:
-      "Information on how pathways are assessed and presented in the TPR.",
-  },
-  {
-    tag: "Insights",
-    description:
-      "Updates, case studies, and stories highlighting how the TPR can be leveraged in real life analyses.",
-  },
-]; */
-
-const tagClassNames: Record<UpdateTag, string> = {
-  Coverage: "border border-sky-200 bg-sky-50 text-sky-800",
-  Functionality: "border border-amber-200 bg-amber-50 text-amber-800",
-  Methodology: "border border-violet-200 bg-violet-50 text-violet-800",
-  Insights: "border border-emerald-200 bg-emerald-50 text-emerald-800",
 };
 
 const posts: UpdatePost[] = [
@@ -47,7 +12,6 @@ const posts: UpdatePost[] = [
   // {
   //   title: "Power sector coverage expanded for Southeast Asia",
   //   date: "May 7, 2026",
-  //   tags: ["Coverage", "Insights"],
   //   body: (
   //     <>
   //       <p>
@@ -65,7 +29,6 @@ const posts: UpdatePost[] = [
     title:
       "Four lessons learned from evaluating the transition pathway landscape in the Southeast Asia power sector",
     date: "May 15, 2026",
-    tags: ["Insights"],
     body: (
       <>
         <p>
@@ -148,7 +111,6 @@ const posts: UpdatePost[] = [
     title:
       "Introducing the Transition Pathways Repository: Making Transition Analysis Actionable",
     date: "December 11, 2025",
-    tags: ["Functionality", "Coverage"],
     body: (
       <>
         <p>
@@ -223,33 +185,6 @@ const ResourcesUpdatesPage: React.FC = () => {
         </section>
 
         <section className="mx-auto mt-12 max-w-5xl">
-          {/* <div className="max-w-5xl">
-            <h2 className="text-2xl font-semibold text-rmigray-800">
-              Categories
-            </h2>
-          </div>
-
-          <div className="mt-8 grid max-w-5xl gap-3 md:grid-cols-2">
-            {categories.map((category) => (
-              <div
-                key={category.tag}
-                className="rounded-2xl border border-neutral-200 bg-neutral-100/80 p-4 shadow-sm"
-              >
-                <span
-                  className={
-                    "inline-flex rounded-full px-3 py-1 text-xs font-semibold " +
-                    tagClassNames[category.tag]
-                  }
-                >
-                  {category.tag}
-                </span>
-                <p className="mt-3 text-sm leading-7 text-rmigray-700">
-                  {category.description}
-                </p>
-              </div>
-            ))}
-          </div> */}
-
           <div className="max-w-5xl">
             <h2 className="text-2xl font-semibold text-rmigray-800 mt-8">
               Latest updates
@@ -263,29 +198,13 @@ const ResourcesUpdatesPage: React.FC = () => {
                   key={`${post.date}-${post.title}`}
                   className="rounded-2xl border border-neutral-200 bg-white p-7 shadow-sm"
                 >
-                  <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
-                    <div className="min-w-0">
-                      <h3 className="text-2xl font-semibold text-rmigray-800">
-                        {post.title}
-                      </h3>
-                      <p className="mt-2 text-sm font-medium text-rmigray-500">
-                        {post.date}
-                      </p>
-                    </div>
-
-                    <div className="flex flex-wrap gap-2 md:justify-end">
-                      {post.tags.map((tag) => (
-                        <span
-                          key={`${post.title}-${tag}`}
-                          className={
-                            "rounded-full px-3 py-1 text-sm font-semibold " +
-                            tagClassNames[tag]
-                          }
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
+                  <div>
+                    <h3 className="text-2xl font-semibold text-rmigray-800">
+                      {post.title}
+                    </h3>
+                    <p className="mt-2 text-sm font-medium text-rmigray-500">
+                      {post.date}
+                    </p>
                   </div>
 
                   <div className="mt-6 space-y-4 text-rmigray-700 leading-7">

--- a/src/pages/resources/ResourcesUseCasesPage.tsx
+++ b/src/pages/resources/ResourcesUseCasesPage.tsx
@@ -42,7 +42,7 @@ const useCases = [
     subtitle:
       "Ambition is often benchmarked on the basis of global 1.5°C pathways. This is a fair approach for a diversified global portfolio, but global pathways that lack regional granularity do not account for local constraints. Region-specific pathways may not always align to a clear temperature outcome, but they can provide a useful indication of what high ambition looks like in a specific region.",
     bullets: [
-      "Test ambition against common global benchmarks: Check if company targetsare leading, lagging, or broadly aligned with global benchmarks.",
+      "Test ambition against common global benchmarks: Check if company targets are leading, lagging, or broadly aligned with global benchmarks.",
       "Understand ambition under local constraints: Complement global benchmarks with region-specific benchmarks to prevent unfairly locking some regions out of transition finance.",
     ],
   },

--- a/src/pages/resources/ResourcesUseCasesPage.tsx
+++ b/src/pages/resources/ResourcesUseCasesPage.tsx
@@ -296,7 +296,7 @@ const ResourcesUseCasesPage: React.FC = () => {
                   The Transition Pathways Repository helps users understand
                   these differences up front — making it easier to choose the
                   most appropriate pathway for their specific objective and
-                  avoid misinterpretationor an inaccurate analysis.
+                  avoid misinterpretation or an inaccurate analysis.
                 </p>
               </div>
             </aside>

--- a/src/pages/resources/ResourcesUseCasesPage.tsx
+++ b/src/pages/resources/ResourcesUseCasesPage.tsx
@@ -1,0 +1,329 @@
+import React from "react";
+
+const financialInstitutionRoles = [
+  {
+    title: "Sustainability",
+    description:
+      "Assess the credibility and ambition of client and portfolio transition plans, benchmark against sectoral and regional pathways, and support alignment with net-zero and climate targets.",
+  },
+  {
+    title: "Risk",
+    description:
+      "Evaluate exposure to transition-related risks, including sectoral misalignment and structural dependencies (e.g., technology, policy, and market conditions), to inform risk management frameworks and stress testing.",
+  },
+  {
+    title: "Front-office (lending, investment, advisory)",
+    description:
+      "Inform client engagement, assess corporate transition plans, corporate deal structuring, and portfolio alignment by identifying credible transition pathways and investment opportunities in low-carbon technologies.",
+  },
+  {
+    title: "Strategy",
+    description:
+      "Identify emerging clean technologies, develop investment theses, and set capital allocation targets to support and steer the teams above.",
+  },
+];
+
+const audienceCards = [
+  {
+    title: "Corporations",
+    description:
+      "Develop and refine corporate transition plans, align business strategies and capital allocation with credible sectoral pathways, and anticipate external dependencies shaping the transition.",
+  },
+  {
+    title: "Public institutions",
+    description:
+      "Support policy design, regulation, and supervisory approaches by identifying priority sectors and technologies, assessing transition feasibility, and pinpointing areas where additional policy support is needed to accelerate progress and capitalize on opportunities.",
+  },
+];
+
+const useCases = [
+  {
+    title: "Assess target ambition",
+    subtitle:
+      "Ambition is often benchmarked on the basis of global 1.5°C pathways. This is a fair approach for a diversified global portfolio, but global pathways that lack regional granularity do not account for local constraints. Region-specific pathways may not always align to a clear temperature outcome, but they can provide a useful indication of what high ambition looks like in a specific region.",
+    bullets: [
+      "Test ambition against common global benchmarks: Check if company targetsare leading, lagging, or broadly aligned with global benchmarks.",
+      "Understand ambition under local constraints: Complement global benchmarks with region-specific benchmarks to prevent unfairly locking some regions out of transition finance.",
+    ],
+  },
+  {
+    title: "Assess feasibility of transition plans",
+    subtitle:
+      "Targets signal intent but need to be balanced with a feasible plan for implementation. Understanding feasibility ensures that credible opportunities are identified for financing and risks can be managed effectively.",
+    bullets: [
+      "Test assumptions: Compare company plans against technology, cost, and deployment assumptions embedded in pathways.",
+      "Assess dependencies: Evaluate reliance on external factors such as policy support, infrastructure, technology availability, or market evolution.",
+    ],
+  },
+  {
+    title: "Identify emerging technologies",
+    subtitle:
+      "Emissions are a lagging indicator for the progression of the energy transition. To understand how the transition may progress, you need to understand the technologies that drive it and how these could scale.",
+    bullets: [
+      "Identify decarbonization levers: Find common technologies across pathways that will be integral to the energy transition within and across sectors.",
+      "Steer capital allocation: Prioritize investments in technologies and sectors consistent with the energy transition to build expertise and gain exposure to new markets.",
+    ],
+  },
+  {
+    title: "Understand transition risks and their drivers",
+    subtitle:
+      "Transition risks are shaped by evolving policies, technologies, and market conditions that can materially impact performance, and are often modeled in pathways.",
+    bullets: [
+      "Map exposure: Evaluate portfolio and corporate sensitivity to policy changes, carbon pricing, and regulatory shifts.",
+      "Analyze market dynamics: Understand how demand, costs, and technology adoption may evolve and impact markets.",
+      "Identify structural dependencies: Assess what enablers such as infrastructure or supply chains need to be in place to support the transition.",
+    ],
+  },
+];
+
+type UseCaseCardProps = {
+  title: string;
+  subtitle: string;
+  bullets: string[];
+};
+
+const UseCaseCard: React.FC<UseCaseCardProps> = ({
+  title,
+  subtitle,
+  bullets,
+}) => {
+  return (
+    <article className="overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm">
+      <div className="border-b border-neutral-200 bg-gradient-to-r from-rmiblue-50 via-white to-white p-6 md:p-7">
+        <div className="flex items-start gap-4">
+          <span className="mt-1 h-12 w-1.5 flex-none rounded-full bg-energy-700" />
+          <div>
+            <h3 className="text-xl font-semibold text-rmigray-800">{title}</h3>
+            <p className="mt-4 max-w-2xl text-sm leading-7 text-rmigray-600">
+              {subtitle}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6 md:p-7">
+        <ul className="space-y-3 text-rmigray-700">
+          {bullets.map((bullet) => (
+            <li
+              key={bullet}
+              className="flex gap-3 rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-4"
+            >
+              <span className="mt-2 h-2.5 w-2.5 flex-none rounded-full bg-energy-700" />
+              <span className="leading-7">{bullet}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </article>
+  );
+};
+
+const AudienceCard: React.FC<{
+  title: string;
+  children: React.ReactNode;
+}> = ({ title, children }) => {
+  return (
+    <article className="rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm">
+      <h3 className="text-lg font-semibold text-rmiblue-800">{title}</h3>
+      <div className="mt-4 text-rmigray-700 leading-7">{children}</div>
+    </article>
+  );
+};
+
+const ResourcesUseCasesPage: React.FC = () => {
+  return (
+    <div className="bg-gray-50">
+      <div className="container mx-auto px-4 py-8 md:py-10">
+        <section className="relative overflow-hidden rounded-[1.75rem] bg-rmiblue-800 px-6 py-8 text-white shadow-lg md:px-10 md:py-11">
+          <div className="absolute inset-0 bg-gradient-to-br from-white/8 via-transparent to-energy-700/10" />
+          <div className="absolute -right-10 top-0 h-32 w-32 rounded-full bg-white/7 blur-2xl" />
+          <div className="absolute bottom-0 left-0 h-40 w-40 rounded-full bg-energy-500/8 blur-2xl" />
+
+          <div className="relative">
+            <h1 className="text-3xl font-bold tracking-tight md:text-4xl">
+              Use cases of RMI’s Transition Pathways Repository
+            </h1>
+
+            <h2 className="mt-6 text-xl font-semibold leading-8 text-white/95 md:text-2xl">
+              Transition pathways are critical to understanding how the energy
+              transition might unfold
+            </h2>
+
+            <div className="mt-8 space-y-4 text-sm leading-7 text-white/85 md:text-base">
+              <p>
+                The energy transition is a technological revolution with
+                dramatic implications for global markets, international
+                development, and geopolitics. It presents one of the greatest
+                economic and industrial opportunities in history, and creates
+                risks for those that fail to adapt and plan accordingly.
+                Transition pathways provide one valuable tool for navigating
+                this uncertainty. It does this by modeling what the future might
+                hold across different regions and sectors under different
+                assumption sets.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-12 max-w-5xl">
+          <div className="max-w-5xl">
+            <h2 className="text-2xl font-semibold text-rmigray-800">
+              Supporting the teams financing the transition
+            </h2>
+            <p className="mt-3 text-rmigray-700 leading-7">
+              The Transition Pathways Repository (TPR) enables financial
+              institutions, public institutions, and other stakeholders to
+              identify, compare, and apply transition pathways for corporate
+              transition assessments and other strategic and analytical
+              applications. It streamlines pathway selection, enhances
+              transparency, and supports the decision-usefulness of analyses.
+            </p>
+            <p className="mt-3 text-rmigray-700 leading-7">
+              The TPR was built primarily to support teams across financial
+              institutions shaping and implementing transition strategies. It is
+              also a valuable resource for corporations and public institutions.
+            </p>
+          </div>
+
+          <div className="mt-8 grid gap-6 xl:grid-cols-[1.35fr,0.95fr]">
+            <AudienceCard title="Financial Institutions">
+              <div className="grid gap-4 sm:grid-cols-2">
+                {financialInstitutionRoles.map((role) => (
+                  <div
+                    key={role.title}
+                    className="rounded-xl border border-neutral-200 bg-neutral-50 p-4"
+                  >
+                    <h4 className="text-sm font-semibold uppercase tracking-[0.12em] text-rmiblue-800">
+                      {role.title}
+                    </h4>
+                    <p className="mt-3 text-sm leading-7 text-rmigray-700">
+                      {role.description}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </AudienceCard>
+
+            <div className="grid gap-6">
+              {audienceCards.map((audience) => (
+                <AudienceCard
+                  key={audience.title}
+                  title={audience.title}
+                >
+                  <p>{audience.description}</p>
+                </AudienceCard>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-14 max-w-5xl">
+          <div className="max-w-5xl">
+            <h2 className="text-2xl font-semibold text-rmigray-800">
+              How the TPR supports decision makers
+            </h2>
+          </div>
+
+          <div className="mt-8 grid grid-cols-1 gap-6 xl:grid-cols-2">
+            {useCases.map((useCase) => (
+              <UseCaseCard
+                key={useCase.title}
+                title={useCase.title}
+                subtitle={useCase.subtitle}
+                bullets={useCase.bullets}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section className="mx-auto mt-14 max-w-5xl">
+          <div className="grid gap-8 xl:grid-cols-[1.2fr,0.8fr]">
+            <div>
+              <h2 className="text-2xl font-semibold text-rmigray-800">
+                How the Transition Pathways Repository supports transition
+                intelligence
+              </h2>
+              <div className="mt-5 space-y-4 text-rmigray-700 leading-7">
+                <p>
+                  Corporate transition assessments should not be a simple
+                  box-checking exercise. Corporate transition assessments should
+                  deliver business value through transition intelligence.
+                </p>
+                <p>
+                  This requires a forward-looking understanding of how sectors
+                  are expected to evolve, the technologies that will underpin
+                  decarbonization, and the external conditions that will shape
+                  the pace and feasibility of change. Transition pathways
+                  provide this essential context, enabling a more rigorous
+                  evaluation of whether corporate strategies are credible,
+                  actionable, and aligned with broader system-level
+                  transformations. See this{" "}
+                  <a
+                    href="https://rmi.org/scaling-transition-intelligence/"
+                    className="text-energy-700 underline underline-offset-2 hover:text-energy-800"
+                  >
+                    case study
+                  </a>{" "}
+                  for an example analysis.
+                </p>
+                <p>
+                  The Transition Pathways Repository supports this by providing
+                  structured, comparable, and transparent pathway data that can
+                  be directly applied in corporate transition assessments.
+                </p>
+              </div>
+            </div>
+
+            <aside>
+              <h2 className="text-2xl font-semibold text-rmigray-800">
+                Why pathway selection matters
+              </h2>
+              <div className="mt-5 space-y-4 text-rmigray-700 leading-7">
+                <p>
+                  No one pathway can provide all the information or answer all
+                  the questions an analyst might have. Different transition
+                  pathways are necessary to answer different questions.
+                </p>
+                <p>
+                  A global 1.5°C pathway may be well suited to assessing the
+                  level of ambition of a global portfolio, while a regional,
+                  policy-driven pathway provides more relevant insights into
+                  risks and dynamics within a specific market. Selecting the
+                  right pathway is therefore critical to ensuring that an
+                  analysis is meaningful, robust, and decision-useful.
+                </p>
+                <p>
+                  The Transition Pathways Repository helps users understand
+                  these differences up front — making it easier to choose the
+                  most appropriate pathway for their specific objective and
+                  avoid misinterpretationor an inaccurate analysis.
+                </p>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section className="mx-auto mt-14 max-w-5xl rounded-[2rem] border border-neutral-200 bg-neutral-100/80 px-6 py-8 shadow-sm md:px-8 md:py-10">
+          <div className="max-w-5xl rounded-2xl border border-neutral-200 bg-white p-7 shadow-sm">
+            <h2 className="text-2xl font-semibold text-rmigray-800">
+              Looking for more information?
+            </h2>
+            <p className="mt-4 text-rmigray-700 leading-7">
+              Find RMI’s thought leadership related to transition intelligence,
+              pathway selection, and other transition finance topics at RMI’s{" "}
+              <a
+                href="https://rmi.org/transitionfinance/"
+                className="text-energy-700 underline underline-offset-2 hover:text-energy-800"
+              >
+                <b>Transition Finance Resource Hub</b>
+              </a>
+              .
+            </p>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default ResourcesUseCasesPage;

--- a/src/pages/resources/index.ts
+++ b/src/pages/resources/index.ts
@@ -1,0 +1,5 @@
+export { default as ResourcesMethodologyPage } from "./ResourcesMethodologyPage";
+export { default as ResourcesHowToChooseAPathwayPage } from "./ResourcesHowToChooseAPathwayPage";
+export { default as ResourcesFaqPage } from "./ResourcesFaqPage";
+export { default as ResourcesUseCasesPage } from "./ResourcesUseCasesPage";
+export { default as ResourcesUpdatesPage } from "./ResourcesUpdatesPage";


### PR DESCRIPTION
closes Monday.com tickets:
- https://rmi.monday.com/boards/18392757091/pulses/11559147816
- https://rmi.monday.com/boards/18392757091/pulses/11047280145
- https://rmi.monday.com/boards/18392757091/pulses/11559190328
- https://rmi.monday.com/boards/18392757091/pulses/11662780984
- https://rmi.monday.com/boards/18392757091/pulses/11047283437
- https://rmi.monday.com/boards/18392757091/pulses/11687443938
- https://rmi.monday.com/boards/18392757091/pulses/11047284849

supersedes https://github.com/RMI/pbtar/pull/753

The PR at hand undertakes some initial revamping of the TPR pages, especially providing first versions of crucial user-supporting documentation. Further adjustments and additions are expected in due time, but this equips users with the fundamental information to make sense of the tool.

Specifically, this PR:
- updates the landing page to explain to the users more clearly what they can expect from using the Transition Pathways Repository, updating copy and adding more scrollable content in line with standard landing pages on similar tools
- adds a dedicated Contact page that explains how to reach us and what types of questions to reach out for
- adds several resource pages that give users context on:
  - How to use the TPR and select a pathway
  - Use cases for our target user groups
  - An overview of the methodology of how we classify pathways
  - An FAQ page
  - An updates page with blog-like editorial content
- updated top bar navigation on the landing page and all other pages where:
  - the title and logo on the top left always lead users back to the revamped landing page
  - the top right corner contains a link to the contact page and a drop down menu that shows all newly added resource pages
- The dropdown and header nav bar components become shared dedicated components used both by the landing page and the contact and resource pages, ensuring consistent behavior across the website