### PR TITLE
feat: persist pathway filters when navigating between cards and detail view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import PathwayDetailPage from "./pages/PathwayDetailPage";
 import LandingPage from "./pages/LandingPage";
 import ContactPage from "./pages/ContactPage";
 import EnvironmentBanner from "./components/EnvironmentBanner";
+import { FilterProvider } from "./context/FilterContext";
 import {
   ResourcesFaqPage,
   ResourcesHowToChooseAPathwayPage,
@@ -80,7 +81,9 @@ export const AppContent = () => {
 function App() {
   return (
     <BrowserRouter>
-      <AppContent />
+      <FilterProvider>
+        <AppContent />
+      </FilterProvider>
     </BrowserRouter>
   );
 }

--- a/src/context/FilterContext.test.tsx
+++ b/src/context/FilterContext.test.tsx
@@ -2,7 +2,12 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Routes, Route, Link } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
-import { FilterProvider, useFilters, EMPTY_FILTERS } from "./FilterContext";
+import {
+  FilterProvider,
+  useFilters,
+  EMPTY_FILTERS,
+  SESSION_KEY,
+} from "./FilterContext";
 import type { SearchFilters } from "../types";
 
 const FilterConsumer = () => {
@@ -64,14 +69,14 @@ describe("FilterContext", () => {
     );
     await u.click(screen.getByTestId("set-filter"));
     const stored = JSON.parse(
-      sessionStorage.getItem("pathway-filters")!,
+      sessionStorage.getItem(SESSION_KEY)!,
     ) as SearchFilters;
     expect(stored.searchTerm).toBe("persistent");
   });
 
   it("hydrates from sessionStorage on mount", () => {
     sessionStorage.setItem(
-      "pathway-filters",
+      SESSION_KEY,
       JSON.stringify({ ...EMPTY_FILTERS, searchTerm: "pre-saved" }),
     );
     render(
@@ -94,11 +99,38 @@ describe("FilterContext", () => {
 
     await u.click(screen.getByTestId("reset"));
     expect(screen.getByTestId("search-term").textContent).toBe("");
-    expect(sessionStorage.getItem("pathway-filters")).toBeNull();
+    expect(sessionStorage.getItem(SESSION_KEY)).toBeNull();
+  });
+
+  it("merges partial sessionStorage data with EMPTY_FILTERS on mount", () => {
+    sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({ searchTerm: "partial" }),
+    );
+    render(
+      <FilterProvider>
+        <FilterConsumer />
+      </FilterProvider>,
+    );
+    expect(screen.getByTestId("search-term").textContent).toBe("partial");
+    expect(screen.getByTestId("geography").textContent).toBe("null");
+  });
+
+  it("coerces non-string searchTerm from sessionStorage to empty string", () => {
+    sessionStorage.setItem(
+      SESSION_KEY,
+      JSON.stringify({ ...EMPTY_FILTERS, searchTerm: 42 }),
+    );
+    render(
+      <FilterProvider>
+        <FilterConsumer />
+      </FilterProvider>,
+    );
+    expect(screen.getByTestId("search-term").textContent).toBe("");
   });
 
   it("falls back to empty filters when sessionStorage contains invalid JSON", () => {
-    sessionStorage.setItem("pathway-filters", "not-valid-json{{{");
+    sessionStorage.setItem(SESSION_KEY, "not-valid-json{{{");
     render(
       <FilterProvider>
         <FilterConsumer />

--- a/src/context/FilterContext.test.tsx
+++ b/src/context/FilterContext.test.tsx
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route, Link } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { FilterProvider, useFilters, EMPTY_FILTERS } from "./FilterContext";
+import type { SearchFilters } from "../types";
+
+const FilterConsumer = () => {
+  const { filters, setFilters, resetFilters } = useFilters();
+  return (
+    <div>
+      <span data-testid="search-term">{filters.searchTerm}</span>
+      <span data-testid="geography">{JSON.stringify(filters.geography)}</span>
+      <button
+        data-testid="set-filter"
+        onClick={() =>
+          setFilters((prev) => ({ ...prev, searchTerm: "persistent" }))
+        }
+      >
+        Set filter
+      </button>
+      <button
+        data-testid="reset"
+        onClick={resetFilters}
+      >
+        Reset
+      </button>
+    </div>
+  );
+};
+
+describe("FilterContext", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("provides empty filters by default", () => {
+    render(
+      <FilterProvider>
+        <FilterConsumer />
+      </FilterProvider>,
+    );
+    expect(screen.getByTestId("search-term").textContent).toBe("");
+    expect(screen.getByTestId("geography").textContent).toBe("null");
+  });
+
+  it("updates filter state when setFilters is called", async () => {
+    const u = userEvent.setup();
+    render(
+      <FilterProvider>
+        <FilterConsumer />
+      </FilterProvider>,
+    );
+    await u.click(screen.getByTestId("set-filter"));
+    expect(screen.getByTestId("search-term").textContent).toBe("persistent");
+  });
+
+  it("writes updated filters to sessionStorage on change", async () => {
+    const u = userEvent.setup();
+    render(
+      <FilterProvider>
+        <FilterConsumer />
+      </FilterProvider>,
+    );
+    await u.click(screen.getByTestId("set-filter"));
+    const stored = JSON.parse(
+      sessionStorage.getItem("pathway-filters")!,
+    ) as SearchFilters;
+    expect(stored.searchTerm).toBe("persistent");
+  });
+
+  it("hydrates from sessionStorage on mount", () => {
+    sessionStorage.setItem(
+      "pathway-filters",
+      JSON.stringify({ ...EMPTY_FILTERS, searchTerm: "pre-saved" }),
+    );
+    render(
+      <FilterProvider>
+        <FilterConsumer />
+      </FilterProvider>,
+    );
+    expect(screen.getByTestId("search-term").textContent).toBe("pre-saved");
+  });
+
+  it("resetFilters clears state and removes the sessionStorage entry", async () => {
+    const u = userEvent.setup();
+    render(
+      <FilterProvider>
+        <FilterConsumer />
+      </FilterProvider>,
+    );
+    await u.click(screen.getByTestId("set-filter"));
+    expect(screen.getByTestId("search-term").textContent).toBe("persistent");
+
+    await u.click(screen.getByTestId("reset"));
+    expect(screen.getByTestId("search-term").textContent).toBe("");
+    expect(sessionStorage.getItem("pathway-filters")).toBeNull();
+  });
+
+  it("falls back to empty filters when sessionStorage contains invalid JSON", () => {
+    sessionStorage.setItem("pathway-filters", "not-valid-json{{{");
+    render(
+      <FilterProvider>
+        <FilterConsumer />
+      </FilterProvider>,
+    );
+    expect(screen.getByTestId("search-term").textContent).toBe("");
+  });
+
+  it("filters persist across simulated route navigation", async () => {
+    const u = userEvent.setup();
+
+    const ListPage = () => (
+      <div>
+        <FilterConsumer />
+        <Link to="/detail/1">Go to detail</Link>
+      </div>
+    );
+    const DetailPage = () => (
+      <div>
+        <span>Detail view</span>
+        <Link to="/">Back to list</Link>
+      </div>
+    );
+
+    render(
+      <FilterProvider>
+        <MemoryRouter initialEntries={["/"]}>
+          <Routes>
+            <Route
+              path="/"
+              element={<ListPage />}
+            />
+            <Route
+              path="/detail/:id"
+              element={<DetailPage />}
+            />
+          </Routes>
+        </MemoryRouter>
+      </FilterProvider>,
+    );
+
+    await u.click(screen.getByTestId("set-filter"));
+    expect(screen.getByTestId("search-term").textContent).toBe("persistent");
+
+    await u.click(screen.getByText("Go to detail"));
+    expect(screen.getByText("Detail view")).toBeInTheDocument();
+
+    await u.click(screen.getByText("Back to list"));
+    expect(screen.getByTestId("search-term").textContent).toBe("persistent");
+  });
+
+  it("throws when useFilters is used outside FilterProvider", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<FilterConsumer />)).toThrow(
+      "useFilters must be used within a FilterProvider",
+    );
+    errorSpy.mockRestore();
+  });
+});

--- a/src/context/FilterContext.tsx
+++ b/src/context/FilterContext.tsx
@@ -1,0 +1,78 @@
+import React, { createContext, use, useState, useCallback } from "react";
+import { SearchFilters } from "../types";
+
+export const EMPTY_FILTERS: SearchFilters = {
+  pathwayType: null,
+  modelYearNetzero: null,
+  modelTempIncrease: null,
+  geography: null,
+  sector: null,
+  metric: null,
+  emissionsTrajectory: null,
+  policyAmbition: null,
+  dataAvailability: null,
+  searchTerm: "",
+};
+
+const SESSION_KEY = "pathway-filters";
+
+function loadFromSession(): SearchFilters {
+  try {
+    const raw = sessionStorage.getItem(SESSION_KEY);
+    return raw ? (JSON.parse(raw) as SearchFilters) : { ...EMPTY_FILTERS };
+  } catch {
+    return { ...EMPTY_FILTERS };
+  }
+}
+
+interface FilterContextValue {
+  filters: SearchFilters;
+  setFilters: React.Dispatch<React.SetStateAction<SearchFilters>>;
+  resetFilters: () => void;
+}
+
+const FilterContext = createContext<FilterContextValue | null>(null);
+FilterContext.displayName = "FilterContext";
+
+export const FilterProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [filters, setFilters] = useState<SearchFilters>(loadFromSession);
+
+  const setFiltersAndPersist: React.Dispatch<
+    React.SetStateAction<SearchFilters>
+  > = useCallback((action) => {
+    setFilters((prev) => {
+      const next = typeof action === "function" ? action(prev) : action;
+      try {
+        sessionStorage.setItem(SESSION_KEY, JSON.stringify(next));
+      } catch {
+        // sessionStorage unavailable (e.g. private browsing with storage blocked)
+      }
+      return next;
+    });
+  }, []);
+
+  const resetFilters = useCallback(() => {
+    try {
+      sessionStorage.removeItem(SESSION_KEY);
+    } catch {
+      // ignore
+    }
+    setFilters({ ...EMPTY_FILTERS });
+  }, []);
+
+  return (
+    <FilterContext
+      value={{ filters, setFilters: setFiltersAndPersist, resetFilters }}
+    >
+      {children}
+    </FilterContext>
+  );
+};
+
+export function useFilters(): FilterContextValue {
+  const ctx = use(FilterContext);
+  if (!ctx) throw new Error("useFilters must be used within a FilterProvider");
+  return ctx;
+}

--- a/src/context/FilterContext.tsx
+++ b/src/context/FilterContext.tsx
@@ -14,7 +14,7 @@ export const EMPTY_FILTERS: SearchFilters = {
   searchTerm: "",
 };
 
-const SESSION_KEY = "pathway-filters";
+export const SESSION_KEY = "pathway-filters";
 
 function loadFromSession(): SearchFilters {
   try {

--- a/src/context/FilterContext.tsx
+++ b/src/context/FilterContext.tsx
@@ -19,7 +19,13 @@ const SESSION_KEY = "pathway-filters";
 function loadFromSession(): SearchFilters {
   try {
     const raw = sessionStorage.getItem(SESSION_KEY);
-    return raw ? (JSON.parse(raw) as SearchFilters) : { ...EMPTY_FILTERS };
+    const parsed = raw ? (JSON.parse(raw) as Partial<SearchFilters>) : {};
+    return {
+      ...EMPTY_FILTERS,
+      ...parsed,
+      searchTerm:
+        typeof parsed.searchTerm === "string" ? parsed.searchTerm : "",
+    };
   } catch {
     return { ...EMPTY_FILTERS };
   }

--- a/src/pages/PathwaySearch.test.tsx
+++ b/src/pages/PathwaySearch.test.tsx
@@ -5,6 +5,7 @@ import PathwaySearch from "./PathwaySearch";
 import { pathwayMetadata } from "../data/pathwayMetadata";
 import { PathwayMetadataType } from "../types";
 import userEvent from "@testing-library/user-event";
+import { FilterProvider } from "../context/FilterContext";
 
 // Mock the PathwayCard component to simplify testing
 vi.mock("../components/PathwayCard", () => ({
@@ -19,10 +20,16 @@ vi.mock("../components/PathwayCard", () => ({
 }));
 
 describe("PathwaySearch component", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
   const renderPathwaySearch = () => {
     return render(
       <MemoryRouter>
-        <PathwaySearch />
+        <FilterProvider>
+          <PathwaySearch />
+        </FilterProvider>
       </MemoryRouter>,
     );
   };
@@ -102,6 +109,7 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
   ] as const;
 
   async function mountWithFixtures(): Promise<void> {
+    sessionStorage.clear();
     // Reset module graph so our mock applies to the next import.
     vi.resetModules();
     // Mock BEFORE importing PathwaySearch
@@ -112,8 +120,18 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
         virtual: true,
       },
     );
-    PathwaySearchUnderTest = (await import("./PathwaySearch")).default;
-    render(<PathwaySearchUnderTest />);
+    // FilterProvider must be imported from the same fresh module graph so
+    // it shares the same React context instance as the re-imported PathwaySearch.
+    const [{ default: Component }, { FilterProvider: FP }] = await Promise.all([
+      import("./PathwaySearch"),
+      import("../context/FilterContext"),
+    ]);
+    PathwaySearchUnderTest = Component;
+    render(
+      <FP>
+        <PathwaySearchUnderTest />
+      </FP>,
+    );
   }
 
   async function openDropdown(labelRegex: RegExp): Promise<HTMLButtonElement> {

--- a/src/pages/PathwaySearch.tsx
+++ b/src/pages/PathwaySearch.tsx
@@ -5,6 +5,7 @@ import StepByStepGuide from "../components/StepByStepGuide";
 import { pathwayMetadata } from "../data/pathwayMetadata";
 import { filterPathways } from "../utils/searchUtils";
 import { SearchFilters, PathwayMetadataType } from "../types";
+import { useFilters } from "../context/FilterContext";
 
 const PathwaySearch: React.FC = () => {
   // Ref for the top section to handle scrolling
@@ -15,18 +16,7 @@ const PathwaySearch: React.FC = () => {
   // State to track if search section is sticky
   const [isSticky, setIsSticky] = useState(false);
 
-  const [filters, setFilters] = useState<SearchFilters>({
-    pathwayType: null,
-    modelYearNetzero: null,
-    modelTempIncrease: null,
-    geography: null,
-    sector: null,
-    metric: null,
-    emissionsTrajectory: null,
-    policyAmbition: null,
-    dataAvailability: null,
-    searchTerm: "",
-  });
+  const { filters, setFilters, resetFilters } = useFilters();
 
   const [filteredPathways, setFilteredPathways] =
     useState<PathwayMetadataType[]>(pathwayMetadata);
@@ -101,20 +91,7 @@ const PathwaySearch: React.FC = () => {
     // Search is already applied through the useEffect
   };
 
-  const handleClear = () => {
-    setFilters({
-      pathwayType: null,
-      modelYearNetzero: null,
-      modelTempIncrease: null,
-      geography: null,
-      sector: null,
-      metric: null,
-      emissionsTrajectory: null,
-      policyAmbition: null,
-      dataAvailability: null,
-      searchTerm: "",
-    });
-  };
+  const handleClear = resetFilters;
 
   return (
     <div className="container mx-auto px-4 py-8 bg-gray-50">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "types": ["node"],
-    "moduleResolution": "node"
+    "moduleResolution": "bundler"
   },
   "files": [],
   "references": [


### PR DESCRIPTION
closes #821 

* Persistent filters introduced when navigating between the Card View and the Detail View, by storing the filter state in a React context
* Behavior is handled in new component `src/context/FilterContext.tsx`
* Test coverage added for the new component (`src/context/FilterContext.test.tsx`), based on the expected behavior described in the underlying GH issue, old tests updated to ensure the persistent filtering behavior is accounted for
* Persistence of filters via context was chosen over adding URL parameters, because there is no need to share URLs with specific filters set